### PR TITLE
rename BugSplatServerURL to BugSplatDatabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,6 @@
-Podfile.lock
-Pods
-BugsplatTester/.DS_Store
-BugsplatTester/Cartfile.resolved
-BugsplatTester/build
 .DS_Store
-BugsplatTester/Carthage
-Carthage
-BugsplatMac.framework.zip
-build
 xcuserdata
 xcframeworks
 Vendor
 archives
-
+symbol-upload-macos

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -24,9 +24,9 @@ FOUNDATION_EXPORT const unsigned char BugSplatVersionString[];
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// An Info.plist app String entry in the form of a fully qualified URL to the BugSplat server including customer database prefix, where crash reports will be submitted.
-/// e.g: https://fred.bugsplat.com/
-#define kBugSplatServerURL @"BugSplatServerURL"
+/// App's Info.plist String entry which is a customer specific BugSplat database name where crash reports will be uploaded.
+/// e.g: "fred" (which will reference the https://fred.bugsplat.com/ database)
+#define kBugSplatDatabase @"BugSplatDatabase"
 
 
 @protocol BugSplatDelegate;

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -52,20 +52,23 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
 {
     NSLog(@"BugSplat start...");
 
-    id serverURLObjectValue = [self.bundle objectForInfoDictionaryKey:@"BugSplatServerURL"];
-    if (serverURLObjectValue == nil) {
-        NSLog(@"*** BugSplatServerURL is missing from your Info.plist - Please add this key/value to the your app's Info.plist ***");
+    id bugSplatDatabaseValue = [self.bundle objectForInfoDictionaryKey:kBugSplatDatabase];
+    if (bugSplatDatabaseValue == nil) {
+        NSLog(@"*** BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist ***");
 
         // NSAssert is set to be ignored in this library in Release builds
-        NSAssert(NO, @"BugSplatServerURL is missing from your Info.plist - Please add this key/value to the your app's Info.plist");
+        NSAssert(NO, @"BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist");
     }
 
-    NSString *serverURL = (NSString *)serverURLObjectValue;
-    NSLog(@"BugSplat BugSplatServerURL set as [%@]", serverURL);
+    NSString *bugSplatDatabase = (NSString *)bugSplatDatabaseValue;
+    NSLog(@"BugSplat BugSplatDatabase set as [%@]", bugSplatDatabase);
+
+    NSString *serverURL = [NSString stringWithFormat: @"https://%@.bugsplat.com/", bugSplatDatabase];
 
     // Uncomment line below to enable HockeySDK logging
 //    [[BITHockeyManager sharedHockeyManager] setLogLevel:BITLogLevelVerbose];
 
+    NSLog(@"BugSplat setServerURL: [%@]", serverURL);
     [[BITHockeyManager sharedHockeyManager] setServerURL:serverURL];
     [[BITHockeyManager sharedHockeyManager] startManager];
 }

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUIApp-Info.plist
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUIApp-Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BugSplatServerURL</key>
-	<string>https://fred.bugsplat.com/</string>
+	<key>BugSplatDatabase</key>
+	<string>fred</string>
 </dict>
 </plist>

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/xcshareddata/xcschemes/BugSplatTest-UIKit-ObjC.xcscheme
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/xcshareddata/xcschemes/BugSplatTest-UIKit-ObjC.xcscheme
@@ -15,10 +15,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-               BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-               BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-               ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+               BlueprintIdentifier = "6341B2442BDC3CA2007EE8AC"
+               BuildableName = "BugSplatTest-UIKit-ObjC.app"
+               BlueprintName = "BugSplatTest-UIKit-ObjC"
+               ReferencedContainer = "container:BugSplatTest-UIKit-ObjC.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -44,10 +44,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-            BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-            BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-            ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+            BlueprintIdentifier = "6341B2442BDC3CA2007EE8AC"
+            BuildableName = "BugSplatTest-UIKit-ObjC.app"
+            BlueprintName = "BugSplatTest-UIKit-ObjC"
+            ReferencedContainer = "container:BugSplatTest-UIKit-ObjC.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -68,10 +68,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-            BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-            BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-            ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+            BlueprintIdentifier = "6341B2442BDC3CA2007EE8AC"
+            BuildableName = "BugSplatTest-UIKit-ObjC.app"
+            BlueprintName = "BugSplatTest-UIKit-ObjC"
+            ReferencedContainer = "container:BugSplatTest-UIKit-ObjC.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/Info.plist
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BugSplatServerURL</key>
-	<string>https://fred.bugsplat.com/</string>
+	<key>BugSplatDatabase</key>
+	<string>fred</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/xcshareddata/xcschemes/BugSplatTest-UIKit-Swift.xcscheme
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/xcshareddata/xcschemes/BugSplatTest-UIKit-Swift.xcscheme
@@ -15,10 +15,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-               BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-               BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-               ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+               BlueprintIdentifier = "6383C71E2BDB1BEF00ABC887"
+               BuildableName = "BugSplatTest-UIKit-Swift.app"
+               BlueprintName = "BugSplatTest-UIKit-Swift"
+               ReferencedContainer = "container:BugSplatTest-UIKit-Swift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -44,10 +44,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-            BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-            BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-            ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+            BlueprintIdentifier = "6383C71E2BDB1BEF00ABC887"
+            BuildableName = "BugSplatTest-UIKit-Swift.app"
+            BlueprintName = "BugSplatTest-UIKit-Swift"
+            ReferencedContainer = "container:BugSplatTest-UIKit-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -68,10 +68,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6341B26F2BDC4DE9007EE8AC"
-            BuildableName = "BugSplatTest-macOS-UIKit-ObjC.app"
-            BlueprintName = "BugSplatTest-macOS-UIKit-ObjC"
-            ReferencedContainer = "container:BugSplatTest-macOS-UIKit-ObjC.xcodeproj">
+            BlueprintIdentifier = "6383C71E2BDB1BEF00ABC887"
+            BuildableName = "BugSplatTest-UIKit-Swift.app"
+            BlueprintName = "BugSplatTest-UIKit-Swift"
+            ReferencedContainer = "container:BugSplatTest-UIKit-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/Info.plist
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BugSplatServerURL</key>
-	<string>https://fred.bugsplat.com/</string>
+	<key>BugSplatDatabase</key>
+	<string>fred</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/Info.plist
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BugSplatServerURL</key>
-	<string>https://fred.bugsplat.com/</string>
+	<key>BugSplatDatabase</key>
+	<string>fred</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ To use this xcframework in your project manually you may:
 
 BugSplat requires a few Xcode configuration steps in order integrate the xcframework with your BugSplat account
 
-- Add the following case sensitive key to your app's Info.plist replacing DATABASE_NAME with your BugSplat database name
+- Add the following case sensitive key to your app's Info.plist replacing DATABASE_NAME with your customer specific BugSplat database name.
 
     ```
-    <key>BugSplatServerURL</key>
-    <string>https://DATABASE_NAME.bugsplat.com/</string>
+    <key>BugSplatDatabase</key>
+    <string>DATABASE_NAME</string>
     ```
     
     NOTE: For macOS apps, you must enable Outgoing network connections (client) in the Signing & Capabilities of the Target.

--- a/makeXCFramework.sh
+++ b/makeXCFramework.sh
@@ -1,7 +1,9 @@
 rm -rf Vendor/*
 rm -rf archives/*
 rm -rf xcframeworks/*
-cp -a ../../HockeySDK-iOS/xcframeworks/HockeySDK.xcframework Vendor/
+rmdir Vendor
+mkdir Vendor
+cp -a ../HockeySDK-iOS/xcframeworks/HockeySDK.xcframework Vendor/
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplat" -destination "generic/platform=iOS" -archivePath "archives/BugSplat-iOS"
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplat" -destination "generic/platform=iOS Simulator" -archivePath "archives/BugSplat-iOS_Simulator"
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplatMac" -destination "generic/platform=macOS" -archivePath "archives/BugSplat-macOS"


### PR DESCRIPTION
### Description

renamed Info.plist key from "BugSplatServerURL" to "BugSplatDatabase" and modified the BugSplat.m to create the correct serverURL from the database name as a hostname prefix to bugsplat.com: aka "fred" + "bugsplat.com" = "https://fred.bugsplat.com"

### Checklist

- [X] Tested manually
- [X] Documentation updated (if applicable)
