### PR TITLE
feat: allow setting bugsplat database from code

### DIFF
--- a/BugSplat.h
+++ b/BugSplat.h
@@ -75,6 +75,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSString *userID;
 
+/** Set the bugsplat database name, which will override the "BugSplatDatabase" Info.plist key value */
+@property (nonatomic, assign) NSString *bugSplatDatabase;
+
 /** Set the user name that should used in the SDK components
 
  Right now this is used by the Crash Manager to attach to a crash report.

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -56,6 +56,22 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
             self.bannerImage = bannerImage;
         }
 #endif
+        
+        id bugSplatDatabaseValue = [self.bundle objectForInfoDictionaryKey:kBugSplatDatabase];
+        if (bugSplatDatabaseValue == nil) {
+            NSLog(@"*** BugSplat init: BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist or use setBugSplatDatabase to set it from code ***");
+
+            // NSAssert is set to be ignored in this library in Release builds
+            NSAssert(NO, @"BugSplat init: BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist or use setBugSplatDatabase to set it from code");
+        } else {
+            NSString *bugSplatDatabase = (NSString *)bugSplatDatabaseValue;
+            NSLog(@"BugSplat init: BugSplat BugSplatDatabase set as [%@]", bugSplatDatabase);
+            
+            NSString *serverURL = [NSString stringWithFormat: @"https://%@.bugsplat.com/", bugSplatDatabase];
+
+            NSLog(@"BugSplat init: setServerURL: [%@]", serverURL);
+            [[BITHockeyManager sharedHockeyManager] setServerURL:serverURL];
+        }
     }
 
     return self;
@@ -64,25 +80,12 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
 - (void)start
 {
     NSLog(@"BugSplat start...");
-
-    id bugSplatDatabaseValue = [self.bundle objectForInfoDictionaryKey:kBugSplatDatabase];
-    if (bugSplatDatabaseValue == nil) {
-        NSLog(@"*** BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist ***");
-
-        // NSAssert is set to be ignored in this library in Release builds
-        NSAssert(NO, @"BugSplatDatabase is missing from your Info.plist - Please add this key/value to the your app's Info.plist");
-    }
-
-    NSString *bugSplatDatabase = (NSString *)bugSplatDatabaseValue;
-    NSLog(@"BugSplat BugSplatDatabase set as [%@]", bugSplatDatabase);
-
-    NSString *serverURL = [NSString stringWithFormat: @"https://%@.bugsplat.com/", bugSplatDatabase];
+    
 
     // Uncomment line below to enable HockeySDK logging
 //    [[BITHockeyManager sharedHockeyManager] setLogLevel:BITLogLevelVerbose];
 
-    NSLog(@"BugSplat setServerURL: [%@]", serverURL);
-    [[BITHockeyManager sharedHockeyManager] setServerURL:serverURL];
+    // setServerUrl will be called from either `init` or `setBugSplatDatabase`
     [[BITHockeyManager sharedHockeyManager] startManager];
 }
 
@@ -99,6 +102,14 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
 - (NSBundle *)bundle
 {
     return [NSBundle mainBundle]; // return app's main bundle, not BugSplat framework's bundle
+}
+
+- (void)setBugSplatDatabase:(NSString *)bugSplatDatabase
+{
+    NSString *serverURL = [NSString stringWithFormat: @"https://%@.bugsplat.com/", bugSplatDatabase];
+
+    NSLog(@"BugSplat setBugSplatDatabase: setServerURL: [%@]", serverURL);
+    [[BITHockeyManager sharedHockeyManager] setServerURL:serverURL];
 }
 
 - (void)setUserID:(NSString *)userID


### PR DESCRIPTION
### Description

Changes:
* add setBugSplatDatabase to BugSplat interface
* move setServerUrl initialization from Info.plist into BugSplat init
* setBugSplatDatabase overrides setServerUrl by a new value

Motivation and context:
When BugSplat is being used from a plug-in to an existing application, changing the host application's `Info.plist` to specify the target BugSplat database is not feasible. A way to set it from a plug-in code is required.

Fixes # (issue)

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
