### PR TITLE
chore: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Build and Release XCFramework
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
 
 # Add permissions block to allow writing
 permissions:
@@ -15,6 +15,14 @@ jobs:
     runs-on: macos-latest
     
     steps:
+    - name: Get Next Version
+      id: semver
+      uses: ietf-tools/semver-action@v1
+      with:
+        token: ${{ secrets.GH_PAT }}
+        prefix: 'v'
+        branch: main
+        
     - name: Create parent directory
       run: |
         mkdir bugsplat-workspace
@@ -88,7 +96,7 @@ jobs:
         CHECKSUM=$(swift package compute-checksum xcframeworks/BugSplat.xcframework.zip)
         
         # Create a temporary file with the new content
-        sed "s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ github.ref_name }}/BugSplat.xcframework.zip\"|" Package.swift > Package.swift.tmp
+        sed "s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ steps.semver.outputs.next }}/BugSplat.xcframework.zip\"|" Package.swift > Package.swift.tmp
         sed "s|checksum: \".*\"|checksum: \"${CHECKSUM}\"|" Package.swift.tmp > Package.swift
         rm Package.swift.tmp
           
@@ -96,16 +104,16 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git config --global user.name "github-actions[bot]"
         git add Package.swift
-        git commit -m "chore: release ${{ github.ref_name }}"
+        git commit -m "chore: release ${{ steps.semver.outputs.next }}"
         git push origin HEAD:main
         
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         files: bugsplat-workspace/bugsplat-apple/xcframeworks/BugSplat.xcframework.zip
-        name: Release ${{ github.ref_name }}
+        name: Release ${{ steps.semver.outputs.next }}
         body: |
-          Release of BugSplat.xcframework version ${{ github.ref_name }}
+          Release of BugSplat.xcframework version ${{ steps.semver.outputs.next }}
           
           This release contains:
           - iOS framework
@@ -115,7 +123,7 @@ jobs:
           Swift Package Manager:
           ```swift
           dependencies: [
-              .package(url: "https://github.com/BugSplat-Git/bugsplat-apple.git", from: "${{ github.ref_name }}")
+              .package(url: "https://github.com/BugSplat-Git/bugsplat-apple.git", from: "${{ steps.semver.outputs.next }}")
           ]
           ```
         draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-and-release:
-    runs-on: macos-latest
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      current: ${{ steps.semver.outputs.current }}
+      next: ${{ steps.semver.outputs.next }}
+      should_build: ${{ steps.check.outputs.should_build }}
     
     steps:
     - name: Get Next Version
@@ -22,7 +26,26 @@ jobs:
         token: ${{ secrets.GH_PAT }}
         prefix: 'v'
         branch: main
-        
+        patchList: chore
+        noVersionBumpBehavior: silent
+
+    - name: Check Version Bump
+      id: check
+      run: |
+        if [ "${{ steps.semver.outputs.next }}" = "${{ steps.semver.outputs.current }}" ]; then
+          echo "No version bump needed. Current version: ${{ steps.semver.outputs.current }}"
+          echo "should_build=false" >> $GITHUB_OUTPUT
+        else
+          echo "Version bump needed from ${{ steps.semver.outputs.current }} to ${{ steps.semver.outputs.next }}"
+          echo "should_build=true" >> $GITHUB_OUTPUT
+        fi
+
+  build-and-release:
+    needs: check-version
+    if: needs.check-version.outputs.should_build == 'true'
+    runs-on: macos-latest
+    
+    steps:
     - name: Create parent directory
       run: |
         mkdir bugsplat-workspace
@@ -96,7 +119,7 @@ jobs:
         CHECKSUM=$(swift package compute-checksum xcframeworks/BugSplat.xcframework.zip)
         
         # Create a temporary file with the new content
-        sed "s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ steps.semver.outputs.next }}/BugSplat.xcframework.zip\"|" Package.swift > Package.swift.tmp
+        sed "s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ needs.check-version.outputs.next }}/BugSplat.xcframework.zip\"|" Package.swift > Package.swift.tmp
         sed "s|checksum: \".*\"|checksum: \"${CHECKSUM}\"|" Package.swift.tmp > Package.swift
         rm Package.swift.tmp
           
@@ -104,16 +127,16 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git config --global user.name "github-actions[bot]"
         git add Package.swift
-        git commit -m "chore: release ${{ steps.semver.outputs.next }}"
+        git commit -m "chore: release ${{ needs.check-version.outputs.next }}"
         git push origin HEAD:main
         
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         files: bugsplat-workspace/bugsplat-apple/xcframeworks/BugSplat.xcframework.zip
-        name: Release ${{ steps.semver.outputs.next }}
+        name: Release ${{ needs.check-version.outputs.next }}
         body: |
-          Release of BugSplat.xcframework version ${{ steps.semver.outputs.next }}
+          Release of BugSplat.xcframework version ${{ needs.check-version.outputs.next }}
           
           This release contains:
           - iOS framework
@@ -123,7 +146,7 @@ jobs:
           Swift Package Manager:
           ```swift
           dependencies: [
-              .package(url: "https://github.com/BugSplat-Git/bugsplat-apple.git", from: "${{ steps.semver.outputs.next }}")
+              .package(url: "https://github.com/BugSplat-Git/bugsplat-apple.git", from: "${{ needs.check-version.outputs.next }}")
           ]
           ```
         draft: false


### PR DESCRIPTION
### Description

With our previous action we created a tag to trigger the release. This doesn't work because the tag gets created before the release commit, so it's pointing to a version of Package.swift that hasn't had its version incremented.

Fixes #17

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
