### PR TITLE
chore: fix release (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         token: ${{ secrets.GH_PAT }}
         prefix: 'v'
         branch: main
-        patchList: chore
         noVersionBumpBehavior: silent
 
     - name: Check Version Bump
@@ -129,10 +128,17 @@ jobs:
         git add Package.swift
         git commit -m "chore: release ${{ needs.check-version.outputs.next }}"
         git push origin HEAD:main
+
+    - name: Create and Push Tag
+      working-directory: bugsplat-workspace/bugsplat-apple
+      run: |
+        git tag ${{ needs.check-version.outputs.next }}
+        git push origin ${{ needs.check-version.outputs.next }}
         
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
+        tag_name: ${{ needs.check-version.outputs.next }}
         files: bugsplat-workspace/bugsplat-apple/xcframeworks/BugSplat.xcframework.zip
         name: Release ${{ needs.check-version.outputs.next }}
         body: |


### PR DESCRIPTION
### Description

Last PR wasn't quite right. We don't actually want to increment for `chore:` tags and we need to create a tag before we can publish a release.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
