### PR TITLE
fix: preserve symlinks in release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         
         # Create zip archive of the framework
         cd xcframeworks
-        zip -r BugSplat.xcframework.zip BugSplat.xcframework
+        zip -y -r BugSplat.xcframework.zip BugSplat.xcframework
         
     - name: Update Package.swift
       working-directory: bugsplat-workspace/bugsplat-apple


### PR DESCRIPTION
### Description

We need to preserve symlinks when zipping our xcframework for release.

![image](https://github.com/user-attachments/assets/f6095980-be39-433b-a532-13b33f149ec5)

https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
