### PR TITLE
fix: ensure bugSplatDatabase defers to Info.plist value, otherwise is set only once and before start is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ xcuserdata
 xcframeworks
 Vendor
 archives
+Tools/symbol-upload-macos

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -75,8 +75,25 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSString *userID;
 
-/** Set the bugsplat database name, which will override the "BugSplatDatabase" Info.plist key value */
-@property (nonatomic, assign) NSString *bugSplatDatabase;
+/**
+ * The database name BugSplat will use to construct the BugSplatDatabase URL where crash reports will be submitted.
+ *
+ * NOTES:
+ * By default, the BugSplat database name is pulled from the App's Info.plist.
+ *
+ * When a third party library or plugin developer is leveraging BugSplat, but the App developer incorporating
+ * the plugin is not using BugSplat, programmatically setting this property would be approperiate.
+ *
+ * Only one BugSplat database can be specified within an App including any third party libraries and plugins.
+ * This means if the Info.plist contains a BugSplat database, attempting to change this property will have no effect.
+ *
+ * Additionally, if the Info.plist does not contain a BugSplat database key and value, the first call to
+ * set this property will set the BugSplat database name. Any subsequent calls to set this property will have no effect.
+ *
+ * Finally, with the above considerations, if programmatic change of this property is desired, it must be set before calling
+ * BugSplat `start` method or it will have no effect.
+ */
+@property (nonatomic, copy, nullable) NSString *bugSplatDatabase;
 
 /** Set the user name that should used in the SDK components
 

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  * By default, the BugSplat database name is pulled from the App's Info.plist.
  *
  * When a third party library or plugin developer is leveraging BugSplat, but the App developer incorporating
- * the plugin is not using BugSplat, programmatically setting this property would be approperiate.
+ * the plugin is not using BugSplat, programmatically setting this property would be appropriate.
  *
  * Only one BugSplat database can be specified within an App including any third party libraries and plugins.
  * This means if the Info.plist contains a BugSplat database, attempting to change this property will have no effect.

--- a/Tools/symbol-upload-macos
+++ b/Tools/symbol-upload-macos
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c543ba2ce3ff93d82c9a88321e95e4c75be1bd5c9855df7684be5209cb48126
-size 125565600


### PR DESCRIPTION
### Description

bugSplatDatabase name should always defer to the value set in Info.plist
If a value is not in Info.plist, it may be set programmatically, but only once, and only before BugSplat start is called.
