### PR TITLE
chore: specify bugsplat-apple by version

### DIFF
--- a/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C53726EB2D654ED000E43801 /* BugSplat in Frameworks */ = {isa = PBXBuildFile; productRef = C53726EA2D654ED000E43801 /* BugSplat */; };
+		C501CF282D6E0C1E00A477C5 /* BugSplat in Frameworks */ = {isa = PBXBuildFile; productRef = C501CF272D6E0C1E00A477C5 /* BugSplat */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,7 +28,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C53726EB2D654ED000E43801 /* BugSplat in Frameworks */,
+				C501CF282D6E0C1E00A477C5 /* BugSplat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,7 +73,7 @@
 			);
 			name = "BugSplatTest-SwiftUI-SPM";
 			packageProductDependencies = (
-				C53726EA2D654ED000E43801 /* BugSplat */,
+				C501CF272D6E0C1E00A477C5 /* BugSplat */,
 			);
 			productName = "BugSplatTest-SwiftUI-SPM";
 			productReference = 637DF00E2D42F46A00DDD8FE /* BugSplatTest-SwiftUI-SPM.app */;
@@ -104,7 +104,7 @@
 			mainGroup = 637DF0052D42F46A00DDD8FE;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				C53726E92D654ED000E43801 /* XCRemoteSwiftPackageReference "bugsplat-apple" */,
+				C501CF262D6E0C1E00A477C5 /* XCRemoteSwiftPackageReference "bugsplat-apple" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 637DF00F2D42F46A00DDD8FE /* Products */;
@@ -364,20 +364,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C53726E92D654ED000E43801 /* XCRemoteSwiftPackageReference "bugsplat-apple" */ = {
+		C501CF262D6E0C1E00A477C5 /* XCRemoteSwiftPackageReference "bugsplat-apple" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/bugsplat-git/bugsplat-apple";
+			repositoryURL = "https://github.com/BugSplat-Git/bugsplat-apple";
 			requirement = {
-				kind = revision;
-				revision = 06459ebd948605b046eac9bdbd4a704d7ff1e2e2;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C53726EA2D654ED000E43801 /* BugSplat */ = {
+		C501CF272D6E0C1E00A477C5 /* BugSplat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C53726E92D654ED000E43801 /* XCRemoteSwiftPackageReference "bugsplat-apple" */;
+			package = C501CF262D6E0C1E00A477C5 /* XCRemoteSwiftPackageReference "bugsplat-apple" */;
 			productName = BugSplat;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "083113c6a9912908d4696bbc1b2bb964d1f2f91e57b697770fab587c6eb3f4e2",
+  "originHash" : "3cfaf58c2fabb27ba8665aae0652c6370e465b008e7e85a57fc54632e011f824",
   "pins" : [
     {
       "identity" : "bugsplat-apple",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bugsplat-git/bugsplat-apple",
       "state" : {
-        "revision" : "06459ebd948605b046eac9bdbd4a704d7ff1e2e2"
+        "revision" : "e09225b7fa0de98dbd409fb211629c2f39070643",
+        "version" : "1.2.2"
       }
     }
   ],


### PR DESCRIPTION
### Description

The old version of the build scripts broke support for installing by version. That ability has been restored and this updates our sample to match.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
