### PR TITLE
chore: fix copyrights

### DIFF
--- a/BugSplat.h
+++ b/BugSplat.h
@@ -1,7 +1,7 @@
 //
 //  BugSplat.h
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -1,7 +1,7 @@
 //
 //  BugSplat.m
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #import <BugSplat/BugSplat.h>

--- a/BugSplatAttachment.h
+++ b/BugSplatAttachment.h
@@ -1,7 +1,7 @@
 //
 //  BugSplatAttachment.h
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/BugSplatAttachment.m
+++ b/BugSplatAttachment.m
@@ -1,7 +1,7 @@
 //
 //  BugSplatAttachment.m
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #import "BugSplatAttachment.h"

--- a/BugSplatDelegate.h
+++ b/BugSplatDelegate.h
@@ -1,7 +1,7 @@
 //
 //  BugSplatDelegate.h
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #if TARGET_OS_OSX

--- a/BugSplatMac.h
+++ b/BugSplatMac.h
@@ -2,7 +2,7 @@
 //  BugSplatMac.h
 //  BugSplat
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 #ifndef BugSplatMac_h

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -2,7 +2,7 @@
 //  ContentView.swift
 //  BugSplatTest-SwiftUI
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 import SwiftUI

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/AppDelegate.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  BugSplatTest-UIKit-Swift
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 import UIKit

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/SceneDelegate.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/SceneDelegate.swift
@@ -2,7 +2,7 @@
 //  SceneDelegate.swift
 //  BugSplatTest-UIKit-Swift
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 import UIKit

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -2,7 +2,7 @@
 //  ViewController.swift
 //  BugSplatTest-UIKit-Swift
 //
-//  Copyright © 2024 BugSplat, LLC. All rights reserved.
+//  Copyright © BugSplat, LLC. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
### Description

BugSplat standard is to not include the year.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
