### PR TITLE
fix: ios notarization error from nested frameworks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,20 +106,30 @@ jobs:
       run: |
         ./makeXCFramework.sh
         
-        # Create zip archive of the framework
+        # Create zip archives of the frameworks
         cd xcframeworks
         zip -y -r BugSplat.xcframework.zip BugSplat.xcframework
+        cd ../Vendor
+        zip -y -r HockeySDK.xcframework.zip HockeySDK.xcframework
+        zip -y -r CrashReporter.xcframework.zip CrashReporter.xcframework
         
     - name: Update Package.swift
       working-directory: bugsplat-workspace/bugsplat-apple
       run: |
-        # Calculate checksum
-        CHECKSUM=$(swift package compute-checksum xcframeworks/BugSplat.xcframework.zip)
+        # Calculate checksums
+        BUGSPLAT_CHECKSUM=$(swift package compute-checksum xcframeworks/BugSplat.xcframework.zip)
+        HOCKEY_CHECKSUM=$(swift package compute-checksum Vendor/HockeySDK.xcframework.zip)
+        CRASHREPORTER_CHECKSUM=$(swift package compute-checksum Vendor/CrashReporter.xcframework.zip)
         
-        # Create a temporary file with the new content
-        sed "s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ needs.check-version.outputs.next }}/BugSplat.xcframework.zip\"|" Package.swift > Package.swift.tmp
-        sed "s|checksum: \".*\"|checksum: \"${CHECKSUM}\"|" Package.swift.tmp > Package.swift
-        rm Package.swift.tmp
+        # Update all frameworks in Package.swift
+        sed -i '' \
+          -e "/name: \"BugSplat\"/,/}/ s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ needs.check-version.outputs.next }}/BugSplat.xcframework.zip\"|" \
+          -e "/name: \"BugSplat\"/,/}/ s|checksum: \".*\"|checksum: \"${BUGSPLAT_CHECKSUM}\"|" \
+          -e "/name: \"HockeySDK\"/,/}/ s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ needs.check-version.outputs.next }}/HockeySDK.xcframework.zip\"|" \
+          -e "/name: \"HockeySDK\"/,/}/ s|checksum: \".*\"|checksum: \"${HOCKEY_CHECKSUM}\"|" \
+          -e "/name: \"CrashReporter\"/,/}/ s|url: \".*\"|url: \"https://github.com/BugSplat-Git/bugsplat-apple/releases/download/${{ needs.check-version.outputs.next }}/CrashReporter.xcframework.zip\"|" \
+          -e "/name: \"CrashReporter\"/,/}/ s|checksum: \".*\"|checksum: \"${CRASHREPORTER_CHECKSUM}\"|" \
+          Package.swift
           
         # Commit and push the updated Package.swift
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -138,15 +148,18 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ needs.check-version.outputs.next }}
-        files: bugsplat-workspace/bugsplat-apple/xcframeworks/BugSplat.xcframework.zip
+        files: |
+          bugsplat-workspace/bugsplat-apple/xcframeworks/BugSplat.xcframework.zip
+          bugsplat-workspace/bugsplat-apple/Vendor/HockeySDK.xcframework.zip
+          bugsplat-workspace/bugsplat-apple/Vendor/CrashReporter.xcframework.zip
         name: Release ${{ needs.check-version.outputs.next }}
         body: |
           Release of BugSplat.xcframework version ${{ needs.check-version.outputs.next }}
           
           This release contains:
-          - iOS framework
-          - iOS Simulator framework
-          - macOS framework
+          - BugSplat.xcframework
+          - HockeySDK.xcframework
+          - CrashReporter.xcframework
           
           Swift Package Manager:
           ```swift

--- a/BugSplat.xcodeproj/project.pbxproj
+++ b/BugSplat.xcodeproj/project.pbxproj
@@ -3,12 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		6341B28C2BDC514C007EE8AC /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */; };
-		6341B28D2BDC514C007EE8AC /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		63598C432BA0CCD500770E43 /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
 		63598C442BA0CCD500770E43 /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
 		637DF0452D49A49C00DDD8FE /* BugSplatUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */; };
@@ -21,7 +20,6 @@
 		63905E972D83912E009CDBEE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 63905E952D83912E009CDBEE /* PrivacyInfo.xcprivacy */; };
 		63C6E2032B92852500AED3E3 /* BugSplat.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C6E1FE2B9283B000AED3E3 /* BugSplat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63D006F62BBF5F3600587FBF /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */; };
-		63D006F72BBF5F3600587FBF /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		63D006FA2BBF785B00587FBF /* BugSplatMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 63D006F92BBF785B00587FBF /* BugSplatMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63E233802B9710420066C7FC /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
 		63E233822B9710420066C7FC /* BugSplatAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 63E2337C2B9710420066C7FC /* BugSplatAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -30,34 +28,9 @@
 		63E233862B9715B50066C7FC /* BugSplat.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C6E1FE2B9283B000AED3E3 /* BugSplat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		6341B28E2BDC514D007EE8AC /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				6341B28D2BDC514C007EE8AC /* HockeySDK.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		63D006F82BBF5F3600587FBF /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				63D006F72BBF5F3600587FBF /* HockeySDK.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		6344718C2B9695C500EBEBEB /* BugSplatDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugSplatDelegate.h; sourceTree = "<group>"; };
-		63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
+		63598C3C2B9BBD6600770E43 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
 		63598C422BA0CCD500770E43 /* BugSplat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugSplat.m; sourceTree = "<group>"; };
 		637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatUtilities.h; sourceTree = "<group>"; };
 		637DF0472D49A50800DDD8FE /* BugSplatUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUtilities.m; sourceTree = "<group>"; };
@@ -161,7 +134,6 @@
 				63C6E1E92B92831A00AED3E3 /* Sources */,
 				63C6E1EA2B92831A00AED3E3 /* Frameworks */,
 				63C6E1EB2B92831A00AED3E3 /* Resources */,
-				6341B28E2BDC514D007EE8AC /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -180,7 +152,6 @@
 				63C6E1F82B9283B000AED3E3 /* Sources */,
 				63C6E1F92B9283B000AED3E3 /* Frameworks */,
 				63C6E1FA2B9283B000AED3E3 /* Resources */,
-				63D006F82BBF5F3600587FBF /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -465,8 +436,6 @@
 		63C6E2012B9283B000AED3E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TN6R4Q475K;
@@ -503,8 +472,6 @@
 		63C6E2022B9283B000AED3E3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TN6R4Q475K;

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,6 +13,10 @@
 		63D006E92BBF4A5700587FBF /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63D006E82BBF4A5700587FBF /* Preview Assets.xcassets */; };
 		63D006F22BBF4C3700587FBF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63D006F12BBF4C3700587FBF /* Assets.xcassets */; };
 		63D006FB2BC0B03700587FBF /* BugSplat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63D006F42BBF569200587FBF /* BugSplat.xcframework */; };
+		63E96A142D973F1700C0C026 /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A122D973F1700C0C026 /* HockeySDK.xcframework */; };
+		63E96A152D973F1700C0C026 /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A122D973F1700C0C026 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A162D973F1700C0C026 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A132D973F1700C0C026 /* CrashReporter.xcframework */; };
+		63E96A172D973F1700C0C026 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A132D973F1700C0C026 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,6 +31,18 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		63E96A182D973F1700C0C026 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				63E96A172D973F1700C0C026 /* CrashReporter.xcframework in Embed Frameworks */,
+				63E96A152D973F1700C0C026 /* HockeySDK.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -36,7 +52,9 @@
 		63D006E32BBF4A5500587FBF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		63D006E82BBF4A5700587FBF /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		63D006F12BBF4C3700587FBF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = "BugSplatTest-SwiftUI/Assets.xcassets"; sourceTree = "<group>"; };
-		63D006F42BBF569200587FBF /* BugSplat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		63D006F42BBF569200587FBF /* BugSplat.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		63E96A122D973F1700C0C026 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = ../../Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
+		63E96A132D973F1700C0C026 /* CrashReporter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../../Vendor/CrashReporter.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +63,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				63D006FB2BC0B03700587FBF /* BugSplat.xcframework in Frameworks */,
+				63E96A142D973F1700C0C026 /* HockeySDK.xcframework in Frameworks */,
+				63E96A162D973F1700C0C026 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,6 +92,8 @@
 		63D006F32BBF569200587FBF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63E96A132D973F1700C0C026 /* CrashReporter.xcframework */,
+				63E96A122D973F1700C0C026 /* HockeySDK.xcframework */,
 				63D006F42BBF569200587FBF /* BugSplat.xcframework */,
 			);
 			name = Frameworks;
@@ -108,6 +130,7 @@
 				63D006DD2BBF4A5500587FBF /* Resources */,
 				63D006FD2BC0B03700587FBF /* Embed Frameworks */,
 				634ABCCF2BD85E8500926648 /* BugSplat Symbol Upload */,
+				63E96A182D973F1700C0C026 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -16,6 +16,10 @@
 		6341B25B2BDC3CA5007EE8AC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6341B25A2BDC3CA5007EE8AC /* main.m */; };
 		6341B2632BDC3D0B007EE8AC /* BugSplat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6341B2622BDC3D0B007EE8AC /* BugSplat.xcframework */; };
 		6341B2642BDC3D0B007EE8AC /* BugSplat.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6341B2622BDC3D0B007EE8AC /* BugSplat.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A212D97403C00C0C026 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A1F2D97403C00C0C026 /* CrashReporter.xcframework */; };
+		63E96A222D97403C00C0C026 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A1F2D97403C00C0C026 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A232D97403C00C0C026 /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A202D97403C00C0C026 /* HockeySDK.xcframework */; };
+		63E96A242D97403C00C0C026 /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A202D97403C00C0C026 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,6 +29,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				63E96A242D97403C00C0C026 /* HockeySDK.xcframework in Embed Frameworks */,
+				63E96A222D97403C00C0C026 /* CrashReporter.xcframework in Embed Frameworks */,
 				6341B2642BDC3D0B007EE8AC /* BugSplat.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -46,6 +52,8 @@
 		6341B2592BDC3CA5007EE8AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6341B25A2BDC3CA5007EE8AC /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		6341B2622BDC3D0B007EE8AC /* BugSplat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		63E96A1F2D97403C00C0C026 /* CrashReporter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../../Vendor/CrashReporter.xcframework; sourceTree = "<group>"; };
+		63E96A202D97403C00C0C026 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = ../../Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +61,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63E96A232D97403C00C0C026 /* HockeySDK.xcframework in Frameworks */,
+				63E96A212D97403C00C0C026 /* CrashReporter.xcframework in Frameworks */,
 				6341B2632BDC3D0B007EE8AC /* BugSplat.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -98,6 +108,8 @@
 		6341B2612BDC3D0A007EE8AC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63E96A1F2D97403C00C0C026 /* CrashReporter.xcframework */,
+				63E96A202D97403C00C0C026 /* HockeySDK.xcframework */,
 				6341B2622BDC3D0B007EE8AC /* BugSplat.xcframework */,
 			);
 			name = Frameworks;

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -15,6 +15,10 @@
 		6383C72A2BDB1BEF00ABC887 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6383C7292BDB1BEF00ABC887 /* Base */; };
 		6383C72C2BDB1BF100ABC887 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6383C72B2BDB1BF100ABC887 /* Assets.xcassets */; };
 		6383C72F2BDB1BF100ABC887 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6383C72E2BDB1BF100ABC887 /* Base */; };
+		63E96A1B2D973FB300C0C026 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A192D973FB300C0C026 /* CrashReporter.xcframework */; };
+		63E96A1C2D973FB300C0C026 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A192D973FB300C0C026 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A1D2D973FB300C0C026 /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A1A2D973FB300C0C026 /* HockeySDK.xcframework */; };
+		63E96A1E2D973FB300C0C026 /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A1A2D973FB300C0C026 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,6 +28,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				63E96A1E2D973FB300C0C026 /* HockeySDK.xcframework in Embed Frameworks */,
+				63E96A1C2D973FB300C0C026 /* CrashReporter.xcframework in Embed Frameworks */,
 				6341B23A2BDB22DE007EE8AC /* BugSplat.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -40,7 +46,9 @@
 		6383C72B2BDB1BF100ABC887 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6383C72E2BDB1BF100ABC887 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6383C7302BDB1BF100ABC887 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6383C7372BDB1C2300ABC887 /* BugSplat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		6383C7372BDB1C2300ABC887 /* BugSplat.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		63E96A192D973FB300C0C026 /* CrashReporter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../../Vendor/CrashReporter.xcframework; sourceTree = "<group>"; };
+		63E96A1A2D973FB300C0C026 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = ../../Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,6 +56,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63E96A1D2D973FB300C0C026 /* HockeySDK.xcframework in Frameworks */,
+				63E96A1B2D973FB300C0C026 /* CrashReporter.xcframework in Frameworks */,
 				6341B2392BDB22DE007EE8AC /* BugSplat.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -89,6 +99,8 @@
 		6383C7362BDB1C2300ABC887 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63E96A192D973FB300C0C026 /* CrashReporter.xcframework */,
+				63E96A1A2D973FB300C0C026 /* HockeySDK.xcframework */,
 				6383C7372BDB1C2300ABC887 /* BugSplat.xcframework */,
 			);
 			name = Frameworks;

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/project.pbxproj
@@ -8,7 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		637DF0D92D72A8CA00DDD8FE /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 637DF0D72D72A69C00DDD8FE /* AppKit.framework */; };
-		637EA8B82D8A24AD008F79E3 /* BugSplat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 637DF06D2D6CE5D600DDD8FE /* BugSplat.xcframework */; };
+		63E96A372D97423B00C0C026 /* BugSplat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 637DF06D2D6CE5D600DDD8FE /* BugSplat.xcframework */; };
+		63E96A3C2D97423F00C0C026 /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A302D97418800C0C026 /* HockeySDK.xcframework */; };
+		63E96A3E2D9742A200C0C026 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A312D97418800C0C026 /* CrashReporter.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,8 +27,10 @@
 
 /* Begin PBXFileReference section */
 		637DF0622D6CE56800DDD8FE /* BugSplatTest-macOS-Tool-CPlusPlus */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "BugSplatTest-macOS-Tool-CPlusPlus"; sourceTree = BUILT_PRODUCTS_DIR; };
-		637DF06D2D6CE5D600DDD8FE /* BugSplat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		637DF06D2D6CE5D600DDD8FE /* BugSplat.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
 		637DF0D72D72A69C00DDD8FE /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		63E96A302D97418800C0C026 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = ../../Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
+		63E96A312D97418800C0C026 /* CrashReporter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../../Vendor/CrashReporter.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -42,8 +46,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63E96A3E2D9742A200C0C026 /* CrashReporter.xcframework in Frameworks */,
+				63E96A3C2D97423F00C0C026 /* HockeySDK.xcframework in Frameworks */,
+				63E96A372D97423B00C0C026 /* BugSplat.xcframework in Frameworks */,
 				637DF0D92D72A8CA00DDD8FE /* AppKit.framework in Frameworks */,
-				637EA8B82D8A24AD008F79E3 /* BugSplat.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,6 +76,8 @@
 		637DF06C2D6CE5D500DDD8FE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63E96A312D97418800C0C026 /* CrashReporter.xcframework */,
+				63E96A302D97418800C0C026 /* HockeySDK.xcframework */,
 				637DF0D72D72A69C00DDD8FE /* AppKit.framework */,
 				637DF06D2D6CE5D600DDD8FE /* BugSplat.xcframework */,
 			);
@@ -84,6 +92,7 @@
 			buildConfigurationList = 637DF0692D6CE56800DDD8FE /* Build configuration list for PBXNativeTarget "BugSplatTest-macOS-Tool-CPlusPlus" */;
 			buildPhases = (
 				637DF05E2D6CE56800DDD8FE /* Sources */,
+				63E96A412D9748C100C0C026 /* Manually Codesign Frameworks */,
 				637DF05F2D6CE56800DDD8FE /* Frameworks */,
 				637DF0602D6CE56800DDD8FE /* CopyFiles */,
 				637DF0982D6E532B00DDD8FE /* BugSplat Symbol Upload */,
@@ -109,7 +118,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastUpgradeCheck = 1610;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					637DF0612D6CE56800DDD8FE = {
 						CreatedOnToolsVersion = 16.1;
@@ -154,6 +163,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nrm -f \"/tmp/Xcode_run_script.log\"\n\n# Xcode doesn't show run script errors in build log.\nexec > \"/tmp/Xcode_run_script.log\" 2>&1\n\n# Ensure symbol upload tool is available\nif [ ! -f \"$PROJECT_DIR/../../Tools/symbol-upload-macos\" ]; then\n    mkdir -p \"$PROJECT_DIR/../../Tools\"\n    cd \"$PROJECT_DIR/../../Tools\"\n    curl -sL -O \"https://app.bugsplat.com/download/symbol-upload-macos\"\n    chmod +x symbol-upload-macos\nfi\n\n# Use osascript(1) to present notification banners; otherwise\nosascript -e 'display notification \"preparing and uploading symbols…\" with title \"BugSplat\"'\n\n\"$PROJECT_DIR\"/../../Tools/symbol-upload-macos -a \"BugSplatTest-macOS-Tool-CPlusPlus\" -b \"Fred\" -u \"fred@bugsplat.com\" -p \"Flintstone\" -f \"**/*.dSYM\" -d \"$BUILT_PRODUCTS_DIR\" -v \"1.0 (1)\"\n";
+		};
+		63E96A412D9748C100C0C026 /* Manually Codesign Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Manually Codesign Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Manually Codesign dependency frameworks. Team ID for cert must match app Team ID.\n# Path to your frameworks\nCRASHREPORTER_PATH=\"${BUILT_PRODUCTS_DIR}/CrashReporter.framework\"\nHOCKEYSDK_PATH=\"${BUILT_PRODUCTS_DIR}/HockeySDK.framework\"\nBUGSPLAT_PATH=\"${BUILT_PRODUCTS_DIR}/BugSplatMac.framework\"\n\n# Sign the frameworks\ncodesign --force --deep --sign \"Apple Distribution: BugSplat, LLC (TN6R4Q475K)\" \"$CRASHREPORTER_PATH\"\ncodesign --force --deep --sign \"Apple Distribution: BugSplat, LLC (TN6R4Q475K)\" \"$HOCKEYSDK_PATH\"\ncodesign --force --deep --sign \"Apple Distribution: BugSplat, LLC (TN6R4Q475K)\" \"$BUGSPLAT_PATH\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -201,6 +229,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -261,6 +290,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -285,11 +315,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TN6R4Q475K;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
@@ -304,11 +335,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TN6R4Q475K;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/xcshareddata/xcschemes/BugSplatTest-macOS-Tool-CPlusPlus.xcscheme
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/xcshareddata/xcschemes/BugSplatTest-macOS-Tool-CPlusPlus.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,6 +14,10 @@
 		6341B27F2BDC4DEB007EE8AC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6341B27E2BDC4DEB007EE8AC /* main.m */; };
 		6341B2882BDC4E02007EE8AC /* BugSplat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6341B2872BDC4E02007EE8AC /* BugSplat.xcframework */; };
 		6341B2892BDC4E02007EE8AC /* BugSplat.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6341B2872BDC4E02007EE8AC /* BugSplat.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A272D9740A100C0C026 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A252D9740A100C0C026 /* CrashReporter.xcframework */; };
+		63E96A282D9740A100C0C026 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A252D9740A100C0C026 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		63E96A292D9740A100C0C026 /* HockeySDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A262D9740A100C0C026 /* HockeySDK.xcframework */; };
+		63E96A2A2D9740A100C0C026 /* HockeySDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63E96A262D9740A100C0C026 /* HockeySDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -23,6 +27,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				63E96A2A2D9740A100C0C026 /* HockeySDK.xcframework in Embed Frameworks */,
+				63E96A282D9740A100C0C026 /* CrashReporter.xcframework in Embed Frameworks */,
 				6341B2892BDC4E02007EE8AC /* BugSplat.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -40,8 +46,10 @@
 		6341B27C2BDC4DEB007EE8AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		6341B27E2BDC4DEB007EE8AC /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		6341B2802BDC4DEB007EE8AC /* BugSplatTest_macOS_UIKit_ObjC.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BugSplatTest_macOS_UIKit_ObjC.entitlements; sourceTree = "<group>"; };
-		6341B2872BDC4E02007EE8AC /* BugSplat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
+		6341B2872BDC4E02007EE8AC /* BugSplat.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = BugSplat.xcframework; path = ../../xcframeworks/BugSplat.xcframework; sourceTree = "<group>"; };
 		636215F72BE0732900A21933 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		63E96A252D9740A100C0C026 /* CrashReporter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = ../../Vendor/CrashReporter.xcframework; sourceTree = "<group>"; };
+		63E96A262D9740A100C0C026 /* HockeySDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:TN6R4Q475K:BugSplat, LLC"; lastKnownFileType = wrapper.xcframework; name = HockeySDK.xcframework; path = ../../Vendor/HockeySDK.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,6 +57,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63E96A292D9740A100C0C026 /* HockeySDK.xcframework in Frameworks */,
+				63E96A272D9740A100C0C026 /* CrashReporter.xcframework in Frameworks */,
 				6341B2882BDC4E02007EE8AC /* BugSplat.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -92,6 +102,8 @@
 		6341B2862BDC4E02007EE8AC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63E96A252D9740A100C0C026 /* CrashReporter.xcframework */,
+				63E96A262D9740A100C0C026 /* HockeySDK.xcframework */,
 				6341B2872BDC4E02007EE8AC /* BugSplat.xcframework */,
 			);
 			name = Frameworks;
@@ -126,7 +138,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastUpgradeCheck = 1610;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					6341B26F2BDC4DE9007EE8AC = {
 						CreatedOnToolsVersion = 15.3;
@@ -333,7 +345,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -361,7 +373,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/xcshareddata/xcschemes/BugSplatTest-macOS-UIKit-ObjC.xcscheme
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/xcshareddata/xcschemes/BugSplatTest-macOS-UIKit-ObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -23,12 +23,12 @@ let package = Package(
         .binaryTarget(
             name: "HockeySDK",
             // this zip should be created from the contents of xcframeworks/HockeySDK.xcframework after combining HockeySDK-Mac and HockeySDK-iOS
-            url: "https://github.com/BugSplat-Git/HockeySDK-iOS/releases/download/vFIXME/HockeySDK.xcframework.zip",
+            url: "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/vFIXME/HockeySDK.xcframework.zip",
             checksum: "FIXME"
         ),
         .binaryTarget(
             name: "CrashReporter",
-            url: "https://github.com/BugSplat-Git/plcrashreporter/releases/download/vFIXME/CrashReporter.xcframework.zip",
+            url: "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/vFIXME/CrashReporter.xcframework.zip",
             checksum: "FIXME"
         ),
         // Add a fake target to satisfy the swift build system

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,25 @@ let package = Package(
     products: [
         .library(
             name: "BugSplat",
-            targets: ["BugSplat"]
+            targets: ["BugSplatPackage"]
         )
     ],
     targets: [
         .binaryTarget(
             name: "BugSplat",
-            url: "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v1.2.4/BugSplat.xcframework.zip",
-            checksum: "8d12099d3c8fbe09d72ae77b1f39625f4ac29ed4dbf951a73dcfac8bb56a24c2"
+            url: "https://github.com/BugSplat-Git/bugsplat-apple/releases/download/vFIXME/BugSplat.xcframework.zip",
+            checksum: "FIXME"
+        ),
+        .binaryTarget(
+            name: "HockeySDK",
+            // this zip should be created from the contents of xcframeworks/HockeySDK.xcframework after combining HockeySDK-Mac and HockeySDK-iOS
+            url: "https://github.com/BugSplat-Git/HockeySDK-iOS/releases/download/vFIXME/HockeySDK.xcframework.zip",
+            checksum: "FIXME"
+        ),
+        .binaryTarget(
+            name: "CrashReporter",
+            url: "https://github.com/BugSplat-Git/plcrashreporter/releases/download/vFIXME/CrashReporter.xcframework.zip",
+            checksum: "FIXME"
         ),
         // Add a fake target to satisfy the swift build system
         // Add a dependency to the .binaryTarget
@@ -26,7 +37,7 @@ let package = Package(
         // Add a fake Swift source: Sources/BugSplatPackage/Empty.swift
         .target(
             name: "BugSplatPackage",
-            dependencies: ["BugSplat"]
+            dependencies: ["BugSplat", "HockeySDK", "CrashReporter"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The BugSplat.xcframework enables posting crash reports from iOS, macOS, and Mac 
 
 ## Integration 🏗️
 
-BugSplat supports multiple methods for installing the xcfamework in a project.
-- Using Swift Package Manager.
-- Manually adding xcframeworks.
+The BugSplat crash reporting SDK can be integrated into your project via the following methods:
+- Using Swift Package Manager
+- Manually adding xcframeworks
 
 ### Swift Package Manager (SPM)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The BugSplat.xcframework enables posting crash reports from iOS, macOS, and Mac 
 ## Integration 🏗️
 
 BugSplat supports multiple methods for installing the xcfamework in a project.
+- Using Swift Package Manager.
+- Manually adding xcframeworks.
 
 ### Swift Package Manager (SPM)
 
@@ -33,13 +35,13 @@ Add the following URL to your project's `Additional Package Dependencies`:
 https://github.com/BugSplat-Git/bugsplat-apple
 ```
 
-### Manual Setup
+### Manually Add xcframeworks
 
-To manually install BugSplat.xcframework in your project:
+To manually integrate BugSplat into your Xcode project, three xcframeworks (BugSplat.xcframework, HockeySDK.xcframework, and CrashReporter.xcframework) need to be added and configured within Xcode.
 
-1. Download the latest release from the [Releases](https://github.com/BugSPlat-Git/bugsplat-apple/releases) page. The release will contain a zip file with the xcframework.
-2. Unzip the archive.
-3. In Xcode, select your app target, then go to the General tab, scroll down to Framework, Libraries, and Embedded Content, then click the "+" and navigate to locate the unzipped BugSplat.xcframework. Once added, select Embed & Sign.
+1. Download the latest released xcframeworks (BugSplat.xcframework.zip, HockeySDK.xcframework.zip, and CrashReporter.xcframework.zip) from the [Releases](https://github.com/BugSPlat-Git/bugsplat-apple/releases) page. Each zip will contain the corresponding xcframework.
+2. Unzip each archive.
+3. In Xcode, select your app target, then go to the General tab, scroll down to Framework, Libraries, and Embedded Content, then click the "+" and navigate to where you unzipped the three archives in step 2. Select BugSplat.xcframework, HockeySDK.xcframework, and CrashReporter.xcframework, then tap the "Add" button. Once added, select Embed & Sign for each xcframework.
 
 ## Usage 🧑‍💻
 
@@ -275,7 +277,7 @@ There are several ways to customize your BugSplat crash reporter.
 
 #### User Details
 
-- Set `askUserDetails` to `NO` to prevent the name and email fields from displaying in the crash reporter UI. Defaults to `YES`.
+- BugSplat for macOS provides the ability for the user to provide a name and email when submitting a crash report. To provide the name and email, set `askUserDetails` to `NO` to prevent the name and email fields from displaying in the crash reporter UI. Defaults to `YES`.
 
 #### Auto Submit
 
@@ -283,7 +285,7 @@ There are several ways to customize your BugSplat crash reporter.
 
 #### Persist User Details
 
-- Set `persistUserDetails` to `YES` to save and restore the user's name and email when presenting the crash reporter dialogue. Defaults to `NO`.
+- BugSplat for macOS provides the ability to persist the user name and email entered in a crash reporter UI. Set `persistUserDetails` to `YES` to save and restore the user's name and email when presenting the crash reporter dialogue. Defaults to `NO`.
 
 #### Expiration Time
 
@@ -291,7 +293,7 @@ There are several ways to customize your BugSplat crash reporter.
 
 #### Attachments
 
-Bugsplat supports uploading attachments with crash reports. There's a delegate method provided by `BugSplatDelegate` that can be implemented to provide attachments to be uploaded.
+Bugsplat supports uploading attachments with crash reports. There's a delegate method provided by `BugSplatDelegate` that can be implemented to provide attachments to be uploaded. Currently, iOS supports only one attachment with crash reports. See additional iOS attachment limitation when using Attributes.
 
 #### Bitcode
 

--- a/makeXCFramework.sh
+++ b/makeXCFramework.sh
@@ -3,8 +3,12 @@ rm -rf archives/*
 rm -rf xcframeworks/*
 rmdir Vendor
 mkdir Vendor
-cp -a ../HockeySDK-iOS/xcframeworks/HockeySDK.xcframework Vendor/
+ditto ../plcrashreporter/xcframeworks/CrashReporter.xcframework Vendor/CrashReporter.xcframework
+ditto ../HockeySDK-iOS/xcframeworks/HockeySDK.xcframework Vendor/HockeySDK.xcframework
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplat" -destination "generic/platform=iOS" -archivePath "archives/BugSplat-iOS"
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplat" -destination "generic/platform=iOS Simulator" -archivePath "archives/BugSplat-iOS_Simulator"
 xcodebuild archive -project BugSplat.xcodeproj -scheme "BugSplatMac" -destination "generic/platform=macOS" -archivePath "archives/BugSplat-macOS"
 xcodebuild -create-xcframework -archive archives/BugSplat-iOS.xcarchive -framework BugSplat.framework -archive archives/BugSplat-iOS_Simulator.xcarchive -framework BugSplat.framework -archive archives/BugSplat-macOS.xcarchive -framework BugSplatMac.framework -output xcframeworks/BugSplat.xcframework
+# Codesign the xcframework for authenticity. It will get resigned by app developer.
+codesign -s "Apple Distribution: BugSplat, LLC (TN6R4Q475K)"  -f --timestamp xcframeworks/BugSplat.xcframework
+


### PR DESCRIPTION
Nested frameworks are not allowed for iOS. 
BugSplat.xcframework cannot embed other frameworks.
Codesign added to makeXCFramework.sh for authenticity and customer confidence. 
This will require that Apple Distribution Certificate for BugSplat, LLC be available in CI/CD system.

Updated Package.swift to create 3 .binaryTarget one for BugSplat, HockeySDK and CrashReporter

**TODO:**
Each xcframework should be separately versioned.
Each xcframework should be separately zipped.
Each xcframework should be separately made available for public download as a versioned zip with checksum.
Package.swift **_must be updated_** for URL and checksum values for each binaryTarget (each framework)

*Example Apps:*

BugSplatTest-SwiftUI-SPM was not updated. It should "just work" after the new BugSplat Swift Package is published along with the dependencies. It should be checked after publishing.

The command-line Mac Demo was updated as follows:
BugSplatTest-macOS-Tool-CPlusPlus was updated to include a new Build Phase Script that signs the frameworks after they are copied to the build directory. The Team IDs of the signing in the Build Phase script must match the Team ID for the App (demo).

The following Example_Apps now depend on BugSplat, HockeySDK and CrashReporter Frameworks. All are embedded and signed by the host app. BugSplatTest-macOS-UIKit-ObjC
BugSplatTest-UIKit-ObjC
BugSplatTest-UIKit-Swift
BugSplatTest-SwiftUI

Fixes # (issue)
- Crash on Launch for iOS

### Checklist

- [x] Tested manually all demos both on iPhone, and on Mac
- [x] Documentation README.md may need to be updated. I forgot to review and check that.
- [x] Reviewed by at least 1 other contributor
