### PR TITLE
fix: remove signing

### DIFF
--- a/BugSplat.xcodeproj/project.pbxproj
+++ b/BugSplat.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		63C6E2012B9283B000AED3E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TN6R4Q475K;
@@ -472,6 +473,7 @@
 		63C6E2022B9283B000AED3E3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TN6R4Q475K;


### PR DESCRIPTION
remove signing during build process because we sign the xcframeworks after with distribution certificate.