### PR TITLE
chore: remove xcode-select instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,19 +334,6 @@ Additional languages may be supported by adding the language bundle and strings 
 
 BugSplat is an open-source project, and we welcome contributions from the community. To configure a development environment, follow the instructions below.
 
-### Prerequisites
-
-> [!WARNING]
-> This project requires Xcode Command Line Tools 15.x to build. Version 16.x will crash when building the project.
-
-Install `Xcode 15.4` by following this [link](https://developer.apple.com/download/more/?q=xcode%2015.4) and searching for `Xcode 15.4`. Download the zip file and copy `Xcode.app` to your Applications folder. If you already have Xcode installed, create a new folder in Applications and copy `Xcode.app` to that folder. Rename `Xcode.app` to `Xcode-15.4.app`.
-
-Open terminal and select the Command Line Tools for Xcode 15.4
-
-```sh
-sudo xcode-select -s /Applications/Xcodes/Xcode-15.4.app
-```
-
 ### Building
 
 Clone this repository and all of the dependencies into a new `BugSplat` folder.


### PR DESCRIPTION
### Description

Will not be needed anymore after getting latest plCrashReporter from upstream.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
