### PR TITLE
feat: add postFeedback API for user feedback submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ xcuserdata
 xcframeworks
 archives
 build/*
+.build
 Tools/symbol-upload-macos

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -222,6 +222,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param description Optional description providing additional detail.
  * @param userName Optional user name. Falls back to the `userName` property if nil.
  * @param userEmail Optional user email. Falls back to the `userEmail` property if nil.
+ * @param attachments Optional array of file attachments to include with the feedback.
  * @param completion Optional completion handler called when the upload finishes.
  *                   The error parameter is nil on success.
  */
@@ -229,6 +230,7 @@ NS_ASSUME_NONNULL_BEGIN
                   description:(nullable NSString *)description
                      userName:(nullable NSString *)userName
                     userEmail:(nullable NSString *)userEmail
+                  attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
                    completion:(nullable void (^)(NSError * _Nullable error))completion;
 
 // macOS specific API

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -227,13 +227,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completion Optional completion handler called when the upload finishes.
  *                   The error parameter is nil on success.
  */
-- (void)postFeedbackWithTitle:(NSString *)title
-                  description:(nullable NSString *)description
-                     userName:(nullable NSString *)userName
-                    userEmail:(nullable NSString *)userEmail
-                       appKey:(nullable NSString *)appKey
-                  attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
-                   completion:(nullable void (^)(NSError * _Nullable error))completion;
+- (void)postFeedback:(NSString *)title
+         description:(nullable NSString *)description
+            userName:(nullable NSString *)userName
+           userEmail:(nullable NSString *)userEmail
+              appKey:(nullable NSString *)appKey
+         attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
+          completion:(nullable void (^)(NSError * _Nullable error))completion
+    NS_SWIFT_NAME(postFeedback(title:description:userName:userEmail:appKey:attachments:completion:));
 
 // macOS specific API
 #if TARGET_OS_OSX

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -222,6 +222,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param description Optional description providing additional detail.
  * @param userName Optional user name. Falls back to the `userName` property if nil.
  * @param userEmail Optional user email. Falls back to the `userEmail` property if nil.
+ * @param appKey Optional application key. Falls back to the `appKey` property if nil.
  * @param attachments Optional array of file attachments to include with the feedback.
  * @param completion Optional completion handler called when the upload finishes.
  *                   The error parameter is nil on success.
@@ -230,6 +231,7 @@ NS_ASSUME_NONNULL_BEGIN
                   description:(nullable NSString *)description
                      userName:(nullable NSString *)userName
                     userEmail:(nullable NSString *)userEmail
+                       appKey:(nullable NSString *)appKey
                   attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
                    completion:(nullable void (^)(NSError * _Nullable error))completion;
 

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -211,6 +211,26 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)setValue:(nullable NSString *)value forAttribute:(NSString *)attribute NS_SWIFT_NAME(set(_:for:));
 
+/**
+ * Submits user feedback (non-crash) to BugSplat.
+ *
+ * This sends a feedback report using crash type ID 36 (User.Feedback).
+ * The feedback is packaged as a JSON file and uploaded via the standard
+ * presigned URL flow.
+ *
+ * @param title The feedback title (required).
+ * @param description Optional description providing additional detail.
+ * @param userName Optional user name. Falls back to the `userName` property if nil.
+ * @param userEmail Optional user email. Falls back to the `userEmail` property if nil.
+ * @param completion Optional completion handler called when the upload finishes.
+ *                   The error parameter is nil on success.
+ */
+- (void)postFeedbackWithTitle:(NSString *)title
+                  description:(nullable NSString *)description
+                     userName:(nullable NSString *)userName
+                    userEmail:(nullable NSString *)userEmail
+                   completion:(nullable void (^)(NSError * _Nullable error))completion;
+
 // macOS specific API
 #if TARGET_OS_OSX
 /*!

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -993,13 +993,13 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 
 #pragma mark - User Feedback
 
-- (void)postFeedbackWithTitle:(NSString *)title
-                  description:(NSString *)description
-                     userName:(NSString *)userName
-                    userEmail:(NSString *)userEmail
-                       appKey:(NSString *)appKey
-                  attachments:(NSArray<BugSplatAttachment *> *)attachments
-                   completion:(void (^)(NSError * _Nullable error))completion
+- (void)postFeedback:(NSString *)title
+         description:(NSString *)description
+            userName:(NSString *)userName
+           userEmail:(NSString *)userEmail
+              appKey:(NSString *)appKey
+         attachments:(NSArray<BugSplatAttachment *> *)attachments
+          completion:(void (^)(NSError * _Nullable error))completion
 {
     BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
     metadata.database = self.bugSplatDatabase;
@@ -1015,7 +1015,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     BugSplatUploadService *uploadService = [[BugSplatUploadService alloc] initWithDatabase:self.bugSplatDatabase
                                                                            applicationName:self.resolvedApplicationName
                                                                         applicationVersion:self.resolvedApplicationVersion];
-    [uploadService uploadFeedbackWithTitle:title description:description attachments:attachments metadata:metadata completion:completion];
+    [uploadService uploadFeedback:title description:description attachments:attachments metadata:metadata completion:completion];
 }
 
 #pragma mark - Properties

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -997,6 +997,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
                   description:(NSString *)description
                      userName:(NSString *)userName
                     userEmail:(NSString *)userEmail
+                  attachments:(NSArray<BugSplatAttachment *> *)attachments
                    completion:(void (^)(NSError * _Nullable error))completion
 {
     BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
@@ -1013,7 +1014,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     BugSplatUploadService *uploadService = [[BugSplatUploadService alloc] initWithDatabase:self.bugSplatDatabase
                                                                            applicationName:self.resolvedApplicationName
                                                                         applicationVersion:self.resolvedApplicationVersion];
-    [uploadService uploadFeedbackWithTitle:title description:description metadata:metadata completion:completion];
+    [uploadService uploadFeedbackWithTitle:title description:description attachments:attachments metadata:metadata completion:completion];
 }
 
 #pragma mark - Properties

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -991,6 +991,31 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     }];
 }
 
+#pragma mark - User Feedback
+
+- (void)postFeedbackWithTitle:(NSString *)title
+                  description:(NSString *)description
+                     userName:(NSString *)userName
+                    userEmail:(NSString *)userEmail
+                   completion:(void (^)(NSError * _Nullable error))completion
+{
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = self.bugSplatDatabase;
+    metadata.applicationName = self.resolvedApplicationName;
+    metadata.applicationVersion = self.resolvedApplicationVersion;
+    metadata.userName = userName ?: self.userName;
+    metadata.userEmail = userEmail ?: self.userEmail;
+    metadata.userDescription = description ?: @"";
+    metadata.applicationKey = self.appKey;
+    metadata.notes = self.notes;
+    metadata.crashTypeId = @"36";
+
+    BugSplatUploadService *uploadService = [[BugSplatUploadService alloc] initWithDatabase:self.bugSplatDatabase
+                                                                           applicationName:self.resolvedApplicationName
+                                                                        applicationVersion:self.resolvedApplicationVersion];
+    [uploadService uploadFeedbackWithTitle:title description:description metadata:metadata completion:completion];
+}
+
 #pragma mark - Properties
 
 - (NSBundle *)bundle

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -997,6 +997,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
                   description:(NSString *)description
                      userName:(NSString *)userName
                     userEmail:(NSString *)userEmail
+                       appKey:(NSString *)appKey
                   attachments:(NSArray<BugSplatAttachment *> *)attachments
                    completion:(void (^)(NSError * _Nullable error))completion
 {
@@ -1007,7 +1008,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     metadata.userName = userName ?: self.userName;
     metadata.userEmail = userEmail ?: self.userEmail;
     metadata.userDescription = description ?: @"";
-    metadata.applicationKey = self.appKey;
+    metadata.applicationKey = appKey ?: self.appKey;
     metadata.notes = self.notes;
     metadata.crashTypeId = @"36";
 

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -994,12 +994,12 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 #pragma mark - User Feedback
 
 - (void)postFeedback:(NSString *)title
-         description:(nullable NSString *)description
-            userName:(nullable NSString *)userName
-           userEmail:(nullable NSString *)userEmail
-              appKey:(nullable NSString *)appKey
-         attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
-          completion:(nullable void (^)(NSError * _Nullable error))completion
+         description:(NSString *)description
+            userName:(NSString *)userName
+           userEmail:(NSString *)userEmail
+              appKey:(NSString *)appKey
+         attachments:(NSArray<BugSplatAttachment *> *)attachments
+          completion:(void (^)(NSError * _Nullable error))completion
 {
     BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
     metadata.database = self.bugSplatDatabase;

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -1012,10 +1012,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     metadata.notes = self.notes;
     metadata.crashTypeId = @"36";
 
-    BugSplatUploadService *uploadService = [[BugSplatUploadService alloc] initWithDatabase:self.bugSplatDatabase
-                                                                           applicationName:self.resolvedApplicationName
-                                                                        applicationVersion:self.resolvedApplicationVersion];
-    [uploadService uploadFeedback:title description:description attachments:attachments metadata:metadata completion:completion];
+    [self.uploadService uploadFeedback:title description:description attachments:attachments metadata:metadata completion:completion];
 }
 
 #pragma mark - Properties

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -994,12 +994,12 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 #pragma mark - User Feedback
 
 - (void)postFeedback:(NSString *)title
-         description:(NSString *)description
-            userName:(NSString *)userName
-           userEmail:(NSString *)userEmail
-              appKey:(NSString *)appKey
-         attachments:(NSArray<BugSplatAttachment *> *)attachments
-          completion:(void (^)(NSError * _Nullable error))completion
+         description:(nullable NSString *)description
+            userName:(nullable NSString *)userName
+           userEmail:(nullable NSString *)userEmail
+              appKey:(nullable NSString *)appKey
+         attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
+          completion:(nullable void (^)(NSError * _Nullable error))completion
 {
     BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
     metadata.database = self.bugSplatDatabase;

--- a/BugSplatUploadService.h
+++ b/BugSplatUploadService.h
@@ -39,6 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSString *crashTime;
 
+/**
+ * The crash type ID to use for this upload.
+ * When set, overrides the default platform-specific crash type ID.
+ * Use @"36" for user feedback submissions.
+ */
+@property (nonatomic, copy, nullable) NSString *crashTypeId;
+
 @end
 
 /**
@@ -96,6 +103,23 @@ typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error,
               attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
                  metadata:(nullable BugSplatCrashMetadata *)metadata
                completion:(BugSplatUploadCompletion)completion;
+
+/**
+ * Uploads user feedback to BugSplat.
+ *
+ * Creates a feedback.json file containing the title and description,
+ * zips it, and uploads using the standard 3-step presigned URL flow
+ * with crashTypeId=36 (User.Feedback).
+ *
+ * @param title The feedback title.
+ * @param description Optional feedback description.
+ * @param metadata Metadata (database, app info, user info, etc).
+ * @param completion Called when upload completes or fails.
+ */
+- (void)uploadFeedbackWithTitle:(NSString *)title
+                    description:(nullable NSString *)description
+                       metadata:(BugSplatCrashMetadata *)metadata
+                     completion:(void (^)(NSError * _Nullable error))completion;
 
 /**
  * Cancels any in-progress upload.

--- a/BugSplatUploadService.h
+++ b/BugSplatUploadService.h
@@ -117,11 +117,11 @@ typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error,
  * @param metadata Metadata (database, app info, user info, etc).
  * @param completion Called when upload completes or fails.
  */
-- (void)uploadFeedbackWithTitle:(NSString *)title
-                    description:(nullable NSString *)description
-                    attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
-                       metadata:(BugSplatCrashMetadata *)metadata
-                     completion:(void (^)(NSError * _Nullable error))completion;
+- (void)uploadFeedback:(NSString *)title
+           description:(nullable NSString *)description
+           attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
+              metadata:(BugSplatCrashMetadata *)metadata
+            completion:(void (^)(NSError * _Nullable error))completion;
 
 /**
  * Cancels any in-progress upload.

--- a/BugSplatUploadService.h
+++ b/BugSplatUploadService.h
@@ -108,16 +108,18 @@ typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error,
  * Uploads user feedback to BugSplat.
  *
  * Creates a feedback.json file containing the title and description,
- * zips it, and uploads using the standard 3-step presigned URL flow
- * with crashTypeId=36 (User.Feedback).
+ * zips it along with any attachments, and uploads using the standard
+ * 3-step presigned URL flow with crashTypeId=36 (User.Feedback).
  *
  * @param title The feedback title.
  * @param description Optional feedback description.
+ * @param attachments Optional array of file attachments to include.
  * @param metadata Metadata (database, app info, user info, etc).
  * @param completion Called when upload completes or fails.
  */
 - (void)uploadFeedbackWithTitle:(NSString *)title
                     description:(nullable NSString *)description
+                    attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
                        metadata:(BugSplatCrashMetadata *)metadata
                      completion:(void (^)(NSError * _Nullable error))completion;
 

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -162,28 +162,35 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
 }
 
 - (void)uploadFeedback:(NSString *)title
-           description:(NSString *)description
-           attachments:(NSArray<BugSplatAttachment *> *)attachments
+           description:(nullable NSString *)description
+           attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
               metadata:(BugSplatCrashMetadata *)metadata
-            completion:(void (^)(NSError * _Nullable error))completion
+            completion:(nullable void (^)(NSError * _Nullable error))completion
 {
-    if (!completion) {
-        NSLog(@"BugSplat: uploadFeedback called with nil completion handler");
-        return;
-    }
+    // Substitute a no-op block so the upload proceeds even without a caller-supplied completion
+    void (^safeCompletion)(NSError * _Nullable) = completion ?: ^(NSError * _Nullable __unused error) {};
 
     @try {
+        // Validate that title is non-nil and non-empty
+        if (!title || title.length == 0) {
+            NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
+                                                 code:BugSplatUploadErrorCodeInvalidData
+                                             userInfo:@{NSLocalizedDescriptionKey: @"Feedback title is required and cannot be empty"}];
+            safeCompletion(error);
+            return;
+        }
+
         metadata.crashTypeId = @"36";
 
         // Create feedback.json content
         NSMutableDictionary *feedbackDict = [NSMutableDictionary dictionary];
-        feedbackDict[@"title"] = title ?: @"";
+        feedbackDict[@"title"] = title;
         feedbackDict[@"description"] = description ?: @"";
 
         NSError *jsonError;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:feedbackDict options:0 error:&jsonError];
         if (jsonError) {
-            completion(jsonError);
+            safeCompletion(jsonError);
             return;
         }
 
@@ -209,7 +216,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData
                                              userInfo:@{NSLocalizedDescriptionKey: @"Failed to create feedback ZIP archive"}];
-            completion(error);
+            safeCompletion(error);
             return;
         }
 
@@ -227,14 +234,14 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                                     size:zipData.length
                               completion:^(NSString *presignedURL, NSError *error) {
             if (error) {
-                completion(error);
+                safeCompletion(error);
                 return;
             }
 
             // Step 2: Upload to S3
             [self uploadData:zipData toPresignedURL:presignedURL completion:^(BOOL success, NSError *uploadError) {
                 if (!success) {
-                    completion(uploadError);
+                    safeCompletion(uploadError);
                     return;
                 }
 
@@ -248,19 +255,19 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                                  completion:^(BOOL commitSuccess, NSError *commitError, NSString *infoUrl) {
                     if (commitSuccess) {
                         NSLog(@"BugSplat: User feedback uploaded successfully");
-                        completion(nil);
+                        safeCompletion(nil);
                     } else {
-                        completion(commitError);
+                        safeCompletion(commitError);
                     }
                 }];
             }];
         }];
     } @catch (NSException *exception) {
-        NSLog(@"BugSplat: Exception in uploadFeedbackWithTitle: %@ - %@", exception.name, exception.reason);
+        NSLog(@"BugSplat: Exception in uploadFeedback: %@ - %@", exception.name, exception.reason);
         NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                              code:BugSplatUploadErrorCodeInvalidData
                                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Exception: %@", exception.reason]}];
-        completion(error);
+        safeCompletion(error);
     }
 }
 

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -162,10 +162,10 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
 }
 
 - (void)uploadFeedback:(NSString *)title
-           description:(nullable NSString *)description
-           attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
+           description:(NSString *)description
+           attachments:(NSArray<BugSplatAttachment *> *)attachments
               metadata:(BugSplatCrashMetadata *)metadata
-            completion:(nullable void (^)(NSError * _Nullable error))completion
+            completion:(void (^)(NSError * _Nullable error))completion
 {
     // Substitute a no-op block so the upload proceeds even without a caller-supplied completion
     void (^safeCompletion)(NSError * _Nullable) = completion ?: ^(NSError * _Nullable __unused error) {};

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -163,6 +163,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
 
 - (void)uploadFeedbackWithTitle:(NSString *)title
                     description:(NSString *)description
+                    attachments:(NSArray<BugSplatAttachment *> *)attachments
                        metadata:(BugSplatCrashMetadata *)metadata
                      completion:(void (^)(NSError * _Nullable error))completion
 {
@@ -186,9 +187,24 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             return;
         }
 
-        // Create zip containing feedback.json using existing zip helper
-        BugSplatZipEntry *feedbackEntry = [BugSplatZipEntry entryWithFilename:@"feedback.json" data:jsonData];
-        NSData *zipData = [BugSplatZipHelper zipEntries:@[feedbackEntry]];
+        // Create zip entries starting with feedback.json
+        NSMutableArray<BugSplatZipEntry *> *zipEntries = [NSMutableArray array];
+        [zipEntries addObject:[BugSplatZipEntry entryWithFilename:@"feedback.json" data:jsonData]];
+
+        // Add all attachments to the ZIP (same pattern as crash report uploads)
+        for (BugSplatAttachment *attachment in attachments) {
+            @try {
+                if (attachment && attachment.attachmentData && attachment.filename) {
+                    [zipEntries addObject:[BugSplatZipEntry entryWithFilename:attachment.filename data:attachment.attachmentData]];
+                    NSLog(@"BugSplat: Adding attachment to feedback ZIP: %@", attachment.filename);
+                }
+            } @catch (NSException *exception) {
+                NSLog(@"BugSplat: Exception adding attachment to feedback ZIP: %@ - %@", exception.name, exception.reason);
+                // Continue with remaining attachments
+            }
+        }
+
+        NSData *zipData = [BugSplatZipHelper zipEntries:zipEntries];
         if (!zipData) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -161,6 +161,93 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
     }
 }
 
+- (void)uploadFeedbackWithTitle:(NSString *)title
+                    description:(NSString *)description
+                       metadata:(BugSplatCrashMetadata *)metadata
+                     completion:(void (^)(NSError * _Nullable error))completion
+{
+    if (!completion) {
+        NSLog(@"BugSplat: uploadFeedbackWithTitle called with nil completion handler");
+        return;
+    }
+
+    @try {
+        metadata.crashTypeId = @"36";
+
+        // Create feedback.json content
+        NSMutableDictionary *feedbackDict = [NSMutableDictionary dictionary];
+        feedbackDict[@"title"] = title ?: @"";
+        feedbackDict[@"description"] = description ?: @"";
+
+        NSError *jsonError;
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:feedbackDict options:0 error:&jsonError];
+        if (jsonError) {
+            completion(jsonError);
+            return;
+        }
+
+        // Create zip containing feedback.json using existing zip helper
+        BugSplatZipEntry *feedbackEntry = [BugSplatZipEntry entryWithFilename:@"feedback.json" data:jsonData];
+        NSData *zipData = [BugSplatZipHelper zipEntries:@[feedbackEntry]];
+        if (!zipData) {
+            NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
+                                                 code:BugSplatUploadErrorCodeInvalidData
+                                             userInfo:@{NSLocalizedDescriptionKey: @"Failed to create feedback ZIP archive"}];
+            completion(error);
+            return;
+        }
+
+        // Use crash-time values from metadata, fall back to upload service defaults
+        NSString *database = metadata.database ?: self.database;
+        NSString *appName = metadata.applicationName ?: self.applicationName;
+        NSString *appVersion = metadata.applicationVersion ?: self.applicationVersion;
+
+        NSString *md5Hash = [BugSplatZipHelper md5HashOfData:zipData];
+
+        // Step 1: Get presigned URL
+        [self getPresignedURLForDatabase:database
+                         applicationName:appName
+                      applicationVersion:appVersion
+                                    size:zipData.length
+                              completion:^(NSString *presignedURL, NSError *error) {
+            if (error) {
+                completion(error);
+                return;
+            }
+
+            // Step 2: Upload to S3
+            [self uploadData:zipData toPresignedURL:presignedURL completion:^(BOOL success, NSError *uploadError) {
+                if (!success) {
+                    completion(uploadError);
+                    return;
+                }
+
+                // Step 3: Commit the upload
+                [self commitUploadWithS3Key:presignedURL
+                                    md5Hash:md5Hash
+                                   database:database
+                            applicationName:appName
+                         applicationVersion:appVersion
+                                   metadata:metadata
+                                 completion:^(BOOL commitSuccess, NSError *commitError, NSString *infoUrl) {
+                    if (commitSuccess) {
+                        NSLog(@"BugSplat: User feedback uploaded successfully");
+                        completion(nil);
+                    } else {
+                        completion(commitError);
+                    }
+                }];
+            }];
+        }];
+    } @catch (NSException *exception) {
+        NSLog(@"BugSplat: Exception in uploadFeedbackWithTitle: %@ - %@", exception.name, exception.reason);
+        NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
+                                             code:BugSplatUploadErrorCodeInvalidData
+                                         userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Exception: %@", exception.reason]}];
+        completion(error);
+    }
+}
+
 - (void)cancelUpload
 {
     [self.currentTask cancel];
@@ -318,13 +405,26 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
     [self appendFormField:@"appName" value:appName boundary:boundary toData:body];
     [self appendFormField:@"appVersion" value:appVersion boundary:boundary toData:body];
     
+    if (metadata.crashTypeId) {
+        [self appendFormField:@"crashTypeId" value:metadata.crashTypeId boundary:boundary toData:body];
+        if ([metadata.crashTypeId isEqualToString:@"36"]) {
+            [self appendFormField:@"crashType" value:@"User.Feedback" boundary:boundary toData:body];
+        } else {
 #if TARGET_OS_OSX
-    [self appendFormField:@"crashType" value:@"macOS" boundary:boundary toData:body];
-    [self appendFormField:@"crashTypeId" value:@"13" boundary:boundary toData:body]; // macOS crash type ID
+            [self appendFormField:@"crashType" value:@"macOS" boundary:boundary toData:body];
 #else
-    [self appendFormField:@"crashType" value:@"iOS" boundary:boundary toData:body];
-    [self appendFormField:@"crashTypeId" value:@"26" boundary:boundary toData:body]; // iOS crash type ID
+            [self appendFormField:@"crashType" value:@"iOS" boundary:boundary toData:body];
 #endif
+        }
+    } else {
+#if TARGET_OS_OSX
+        [self appendFormField:@"crashType" value:@"macOS" boundary:boundary toData:body];
+        [self appendFormField:@"crashTypeId" value:@"13" boundary:boundary toData:body];
+#else
+        [self appendFormField:@"crashType" value:@"iOS" boundary:boundary toData:body];
+        [self appendFormField:@"crashTypeId" value:@"26" boundary:boundary toData:body];
+#endif
+    }
     
     [self appendFormField:@"s3key" value:s3Key boundary:boundary toData:body];
     [self appendFormField:@"md5" value:md5Hash boundary:boundary toData:body];

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -161,14 +161,14 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
     }
 }
 
-- (void)uploadFeedbackWithTitle:(NSString *)title
-                    description:(NSString *)description
-                    attachments:(NSArray<BugSplatAttachment *> *)attachments
-                       metadata:(BugSplatCrashMetadata *)metadata
-                     completion:(void (^)(NSError * _Nullable error))completion
+- (void)uploadFeedback:(NSString *)title
+           description:(NSString *)description
+           attachments:(NSArray<BugSplatAttachment *> *)attachments
+              metadata:(BugSplatCrashMetadata *)metadata
+            completion:(void (^)(NSError * _Nullable error))completion
 {
     if (!completion) {
-        NSLog(@"BugSplat: uploadFeedbackWithTitle called with nil completion handler");
+        NSLog(@"BugSplat: uploadFeedback called with nil completion handler");
         return;
     }
 

--- a/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
+    @State var feedbackTitle: String = ""
+    @State var feedbackDescription: String = ""
     @State var feedbackStatus: String?
 
     let prop: Int? = nil
@@ -53,13 +55,22 @@ struct ContentView: View {
             .background(Color.accentColor)
             .cornerRadius(10)
 
+            TextField("Feedback title", text: $feedbackTitle)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+
+            TextField("Description", text: $feedbackDescription)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+
             Button("Send Feedback") {
                 sendFeedback()
             }
             .padding()
             .foregroundColor(.white)
-            .background(Color.green)
+            .background(feedbackTitle.isEmpty ? Color.gray : Color.green)
             .cornerRadius(10)
+            .disabled(feedbackTitle.isEmpty)
 
             if let feedbackStatus {
                 Text(feedbackStatus)
@@ -86,8 +97,8 @@ struct ContentView: View {
     func sendFeedback() {
         feedbackStatus = "Sending..."
         BugSplat.shared().postFeedback(
-            title: "User Feedback",
-            description: "This is a test feedback submission from the SwiftUI SPM example app.",
+            title: feedbackTitle,
+            description: feedbackDescription.isEmpty ? nil : feedbackDescription,
             userName: nil,
             userEmail: nil,
             appKey: nil,
@@ -98,6 +109,8 @@ struct ContentView: View {
                     feedbackStatus = "Failed: \(error.localizedDescription)"
                 } else {
                     feedbackStatus = "Feedback sent!"
+                    feedbackTitle = ""
+                    feedbackDescription = ""
                 }
             }
         }

--- a/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
@@ -12,8 +12,9 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
-    @State var feedbackTitle: String = ""
-    @State var feedbackDescription: String = ""
+    @State var showFeedbackAlert = false
+    @State var feedbackTitle = ""
+    @State var feedbackDescription = ""
     @State var feedbackStatus: String?
 
     let prop: Int? = nil
@@ -55,22 +56,13 @@ struct ContentView: View {
             .background(Color.accentColor)
             .cornerRadius(10)
 
-            TextField("Feedback title", text: $feedbackTitle)
-                .textFieldStyle(.roundedBorder)
-                .padding(.horizontal)
-
-            TextField("Description", text: $feedbackDescription)
-                .textFieldStyle(.roundedBorder)
-                .padding(.horizontal)
-
             Button("Send Feedback") {
-                sendFeedback()
+                showFeedbackAlert = true
             }
             .padding()
             .foregroundColor(.white)
-            .background(feedbackTitle.isEmpty ? Color.gray : Color.green)
+            .background(Color.green)
             .cornerRadius(10)
-            .disabled(feedbackTitle.isEmpty)
 
             if let feedbackStatus {
                 Text(feedbackStatus)
@@ -86,6 +78,12 @@ struct ContentView: View {
         }
         .onChange(of: isFeature3Active) {
             update(attribute: "Feature3", value: isFeature3Active.description)
+        }
+        .alert("Send Feedback", isPresented: $showFeedbackAlert) {
+            TextField("Title", text: $feedbackTitle)
+            TextField("Description", text: $feedbackDescription)
+            Button("Send") { sendFeedback() }
+            Button("Cancel", role: .cancel) { }
         }
     }
 

--- a/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI-SPM/BugSplatTest-SwiftUI-SPM/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
+    @State var feedbackStatus: String?
 
     let prop: Int? = nil
 
@@ -51,6 +52,20 @@ struct ContentView: View {
             .foregroundColor(.white)
             .background(Color.accentColor)
             .cornerRadius(10)
+
+            Button("Send Feedback") {
+                sendFeedback()
+            }
+            .padding()
+            .foregroundColor(.white)
+            .background(Color.green)
+            .cornerRadius(10)
+
+            if let feedbackStatus {
+                Text(feedbackStatus)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
+            }
         }
         .onChange(of: isFeature1Active) {
             update(attribute: "Feature1", value: isFeature1Active.description)
@@ -66,6 +81,26 @@ struct ContentView: View {
     func update(attribute: String, value: String?) {
         print("update(\(attribute), value: \(value ?? "nil")")
         BugSplat.shared().set(value, for: attribute)
+    }
+
+    func sendFeedback() {
+        feedbackStatus = "Sending..."
+        BugSplat.shared().postFeedback(
+            title: "User Feedback",
+            description: "This is a test feedback submission from the SwiftUI SPM example app.",
+            userName: nil,
+            userEmail: nil,
+            appKey: nil,
+            attachments: nil
+        ) { error in
+            DispatchQueue.main.async {
+                if let error {
+                    feedbackStatus = "Failed: \(error.localizedDescription)"
+                } else {
+                    feedbackStatus = "Feedback sent!"
+                }
+            }
+        }
     }
 
 }

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
+    @State var feedbackTitle: String = ""
+    @State var feedbackDescription: String = ""
     @State var feedbackStatus: String?
 
     let prop: Int? = nil
@@ -53,13 +55,22 @@ struct ContentView: View {
             .background(Color.accentColor)
             .cornerRadius(10)
 
+            TextField("Feedback title", text: $feedbackTitle)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+
+            TextField("Description", text: $feedbackDescription)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal)
+
             Button("Send Feedback") {
                 sendFeedback()
             }
             .padding()
             .foregroundColor(.white)
-            .background(Color.green)
+            .background(feedbackTitle.isEmpty ? Color.gray : Color.green)
             .cornerRadius(10)
+            .disabled(feedbackTitle.isEmpty)
 
             if let feedbackStatus {
                 Text(feedbackStatus)
@@ -86,8 +97,8 @@ struct ContentView: View {
     func sendFeedback() {
         feedbackStatus = "Sending..."
         BugSplat.shared().postFeedback(
-            title: "User Feedback",
-            description: "This is a test feedback submission from the SwiftUI example app.",
+            title: feedbackTitle,
+            description: feedbackDescription.isEmpty ? nil : feedbackDescription,
             userName: nil,
             userEmail: nil,
             appKey: nil,
@@ -98,6 +109,8 @@ struct ContentView: View {
                     feedbackStatus = "Failed: \(error.localizedDescription)"
                 } else {
                     feedbackStatus = "Feedback sent!"
+                    feedbackTitle = ""
+                    feedbackDescription = ""
                 }
             }
         }

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -12,8 +12,9 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
-    @State var feedbackTitle: String = ""
-    @State var feedbackDescription: String = ""
+    @State var showFeedbackAlert = false
+    @State var feedbackTitle = ""
+    @State var feedbackDescription = ""
     @State var feedbackStatus: String?
 
     let prop: Int? = nil
@@ -55,22 +56,13 @@ struct ContentView: View {
             .background(Color.accentColor)
             .cornerRadius(10)
 
-            TextField("Feedback title", text: $feedbackTitle)
-                .textFieldStyle(.roundedBorder)
-                .padding(.horizontal)
-
-            TextField("Description", text: $feedbackDescription)
-                .textFieldStyle(.roundedBorder)
-                .padding(.horizontal)
-
             Button("Send Feedback") {
-                sendFeedback()
+                showFeedbackAlert = true
             }
             .padding()
             .foregroundColor(.white)
-            .background(feedbackTitle.isEmpty ? Color.gray : Color.green)
+            .background(Color.green)
             .cornerRadius(10)
-            .disabled(feedbackTitle.isEmpty)
 
             if let feedbackStatus {
                 Text(feedbackStatus)
@@ -86,6 +78,12 @@ struct ContentView: View {
         }
         .onChange(of: isFeature3Active) {
             update(attribute: "Feature3", value: isFeature3Active.description)
+        }
+        .alert("Send Feedback", isPresented: $showFeedbackAlert) {
+            TextField("Title", text: $feedbackTitle)
+            TextField("Description", text: $feedbackDescription)
+            Button("Send") { sendFeedback() }
+            Button("Cancel", role: .cancel) { }
         }
     }
 

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State var isFeature1Active: Bool = false
     @State var isFeature2Active: Bool = false
     @State var isFeature3Active: Bool = false
+    @State var feedbackStatus: String?
 
     let prop: Int? = nil
 
@@ -51,6 +52,20 @@ struct ContentView: View {
             .foregroundColor(.white)
             .background(Color.accentColor)
             .cornerRadius(10)
+
+            Button("Send Feedback") {
+                sendFeedback()
+            }
+            .padding()
+            .foregroundColor(.white)
+            .background(Color.green)
+            .cornerRadius(10)
+
+            if let feedbackStatus {
+                Text(feedbackStatus)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
+            }
         }
         .onChange(of: isFeature1Active) {
             update(attribute: "Feature1", value: isFeature1Active.description)
@@ -66,6 +81,26 @@ struct ContentView: View {
     func update(attribute: String, value: String?) {
         print("update(\(attribute), value: \(value ?? "nil")")
         BugSplat.shared().set(value, for: attribute)
+    }
+
+    func sendFeedback() {
+        feedbackStatus = "Sending..."
+        BugSplat.shared().postFeedback(
+            title: "User Feedback",
+            description: "This is a test feedback submission from the SwiftUI example app.",
+            userName: nil,
+            userEmail: nil,
+            appKey: nil,
+            attachments: nil
+        ) { error in
+            DispatchQueue.main.async {
+                if let error {
+                    feedbackStatus = "Failed: \(error.localizedDescription)"
+                } else {
+                    feedbackStatus = "Feedback sent!"
+                }
+            }
+        }
     }
 
 }

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -22,6 +22,17 @@
     // Attributes can be set any time and can contain dynamic values
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"ViewDidLoadDateTime"];
+
+    // Add a "Send Feedback" button programmatically
+    UIButton *feedbackButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [feedbackButton setTitle:@"Send Feedback" forState:UIControlStateNormal];
+    [feedbackButton addTarget:self action:@selector(sendFeedback) forControlEvents:UIControlEventTouchUpInside];
+    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:feedbackButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:60]
+    ]];
 }
 
 - (IBAction)crashApp:(id)sender {
@@ -29,5 +40,20 @@
     NSLog(@"number = %ld", [number longValue]);
 }
 
+- (void)sendFeedback {
+    [[BugSplat shared] postFeedback:@"User Feedback"
+                        description:@"This is a test feedback submission from the UIKit ObjC example app."
+                           userName:nil
+                          userEmail:nil
+                             appKey:nil
+                        attachments:nil
+                         completion:^(NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"Feedback failed: %@", error.localizedDescription);
+        } else {
+            NSLog(@"Feedback submitted successfully!");
+        }
+    }];
+}
 
 @end

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -9,8 +9,7 @@
 #import <BugSplat/BugSplat.h>
 
 @interface ViewController ()
-@property (nonatomic, strong) UITextField *titleField;
-@property (nonatomic, strong) UITextField *descriptionField;
+
 @end
 
 @implementation ViewController
@@ -24,28 +23,15 @@
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"ViewDidLoadDateTime"];
 
-    // Add feedback input fields and button programmatically
-    self.titleField = [[UITextField alloc] init];
-    self.titleField.placeholder = @"Feedback title";
-    self.titleField.borderStyle = UITextBorderStyleRoundedRect;
-
-    self.descriptionField = [[UITextField alloc] init];
-    self.descriptionField.placeholder = @"Description";
-    self.descriptionField.borderStyle = UITextBorderStyleRoundedRect;
-
+    // Add a "Send Feedback" button that presents a dialog
     UIButton *feedbackButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [feedbackButton setTitle:@"Send Feedback" forState:UIControlStateNormal];
-    [feedbackButton addTarget:self action:@selector(sendFeedback) forControlEvents:UIControlEventTouchUpInside];
-
-    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[self.titleField, self.descriptionField, feedbackButton]];
-    stack.axis = UILayoutConstraintAxisVertical;
-    stack.spacing = 12;
-    stack.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:stack];
+    [feedbackButton addTarget:self action:@selector(showFeedbackDialog) forControlEvents:UIControlEventTouchUpInside];
+    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:feedbackButton];
     [NSLayoutConstraint activateConstraints:@[
-        [stack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-        [stack.topAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40],
-        [self.titleField.widthAnchor constraintEqualToConstant:280],
+        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:60]
     ]];
 }
 
@@ -54,28 +40,35 @@
     NSLog(@"number = %ld", [number longValue]);
 }
 
-- (void)sendFeedback {
-    NSString *title = self.titleField.text;
-    if (title.length == 0) return;
-    NSString *description = self.descriptionField.text.length > 0 ? self.descriptionField.text : nil;
+- (void)showFeedbackDialog {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Send Feedback" message:nil preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.placeholder = @"Title";
+    }];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.placeholder = @"Description";
+    }];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Send" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        NSString *title = alert.textFields[0].text;
+        if (title.length == 0) return;
+        NSString *description = alert.textFields[1].text.length > 0 ? alert.textFields[1].text : nil;
 
-    [[BugSplat shared] postFeedback:title
-                        description:description
-                           userName:nil
-                          userEmail:nil
-                             appKey:nil
-                        attachments:nil
-                         completion:^(NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        [[BugSplat shared] postFeedback:title
+                            description:description
+                               userName:nil
+                              userEmail:nil
+                                 appKey:nil
+                            attachments:nil
+                             completion:^(NSError * _Nullable error) {
             if (error) {
                 NSLog(@"Feedback failed: %@", error.localizedDescription);
             } else {
                 NSLog(@"Feedback submitted successfully!");
-                self.titleField.text = @"";
-                self.descriptionField.text = @"";
             }
-        });
-    }];
+        }];
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 @end

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -9,7 +9,8 @@
 #import <BugSplat/BugSplat.h>
 
 @interface ViewController ()
-
+@property (nonatomic, strong) UITextField *titleField;
+@property (nonatomic, strong) UITextField *descriptionField;
 @end
 
 @implementation ViewController
@@ -23,15 +24,28 @@
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"ViewDidLoadDateTime"];
 
-    // Add a "Send Feedback" button programmatically
+    // Add feedback input fields and button programmatically
+    self.titleField = [[UITextField alloc] init];
+    self.titleField.placeholder = @"Feedback title";
+    self.titleField.borderStyle = UITextBorderStyleRoundedRect;
+
+    self.descriptionField = [[UITextField alloc] init];
+    self.descriptionField.placeholder = @"Description";
+    self.descriptionField.borderStyle = UITextBorderStyleRoundedRect;
+
     UIButton *feedbackButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [feedbackButton setTitle:@"Send Feedback" forState:UIControlStateNormal];
     [feedbackButton addTarget:self action:@selector(sendFeedback) forControlEvents:UIControlEventTouchUpInside];
-    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:feedbackButton];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[self.titleField, self.descriptionField, feedbackButton]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 12;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:stack];
     [NSLayoutConstraint activateConstraints:@[
-        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:60]
+        [stack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [stack.topAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40],
+        [self.titleField.widthAnchor constraintEqualToConstant:280],
     ]];
 }
 
@@ -41,18 +55,26 @@
 }
 
 - (void)sendFeedback {
-    [[BugSplat shared] postFeedback:@"User Feedback"
-                        description:@"This is a test feedback submission from the UIKit ObjC example app."
+    NSString *title = self.titleField.text;
+    if (title.length == 0) return;
+    NSString *description = self.descriptionField.text.length > 0 ? self.descriptionField.text : nil;
+
+    [[BugSplat shared] postFeedback:title
+                        description:description
                            userName:nil
                           userEmail:nil
                              appKey:nil
                         attachments:nil
                          completion:^(NSError * _Nullable error) {
-        if (error) {
-            NSLog(@"Feedback failed: %@", error.localizedDescription);
-        } else {
-            NSLog(@"Feedback submitted successfully!");
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error) {
+                NSLog(@"Feedback failed: %@", error.localizedDescription);
+            } else {
+                NSLog(@"Feedback submitted successfully!");
+                self.titleField.text = @"";
+                self.descriptionField.text = @"";
+            }
+        });
     }];
 }
 

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -61,11 +61,12 @@
                                  appKey:nil
                             attachments:nil
                              completion:^(NSError * _Nullable error) {
-            if (error) {
-                NSLog(@"Feedback failed: %@", error.localizedDescription);
-            } else {
-                NSLog(@"Feedback submitted successfully!");
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSString *message = error ? [NSString stringWithFormat:@"Failed: %@", error.localizedDescription] : @"Feedback submitted successfully!";
+                UIAlertController *confirm = [UIAlertController alertControllerWithTitle:nil message:message preferredStyle:UIAlertControllerStyleAlert];
+                [confirm addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                [self presentViewController:confirm animated:YES completion:nil];
+            });
         }];
     }]];
     [self presentViewController:alert animated:YES completion:nil];

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -55,11 +55,12 @@ class ViewController: UIViewController {
                 userEmail: nil,
                 appKey: nil,
                 attachments: nil
-            ) { error in
-                if let error {
-                    print("Feedback failed: \(error.localizedDescription)")
-                } else {
-                    print("Feedback submitted successfully!")
+            ) { [weak self] error in
+                DispatchQueue.main.async {
+                    let message = error != nil ? "Failed: \(error!.localizedDescription)" : "Feedback submitted successfully!"
+                    let confirm = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+                    confirm.addAction(UIAlertAction(title: "OK", style: .default))
+                    self?.present(confirm, animated: true)
                 }
             }
         })

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -20,6 +20,17 @@ class ViewController: UIViewController {
         // Attributes can be set any time and can contain dynamic values
         // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
         BugSplat.shared().set(NSDate().description, for: "ViewDidLoadDateTime")
+
+        // Add a "Send Feedback" button programmatically
+        let feedbackButton = UIButton(type: .system)
+        feedbackButton.setTitle("Send Feedback", for: .normal)
+        feedbackButton.addTarget(self, action: #selector(sendFeedback), for: .touchUpInside)
+        feedbackButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(feedbackButton)
+        NSLayoutConstraint.activate([
+            feedbackButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            feedbackButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 60)
+        ])
     }
 
     @IBAction func crashApp(_ sender: Any) {
@@ -27,5 +38,22 @@ class ViewController: UIViewController {
         let description = nonOptional!.debugDescription
         print(description)
     }
-    
+
+    @objc func sendFeedback() {
+        BugSplat.shared().postFeedback(
+            title: "User Feedback",
+            description: "This is a test feedback submission from the UIKit Swift example app.",
+            userName: nil,
+            userEmail: nil,
+            appKey: nil,
+            attachments: nil
+        ) { error in
+            if let error {
+                print("Feedback failed: \(error.localizedDescription)")
+            } else {
+                print("Feedback submitted successfully!")
+            }
+        }
+    }
+
 }

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -12,20 +12,6 @@ import BugSplat
 class ViewController: UIViewController {
     var nonOptional: NSObject!
 
-    private let titleField: UITextField = {
-        let field = UITextField()
-        field.placeholder = "Feedback title"
-        field.borderStyle = .roundedRect
-        return field
-    }()
-
-    private let descriptionField: UITextField = {
-        let field = UITextField()
-        field.placeholder = "Description"
-        field.borderStyle = .roundedRect
-        return field
-    }()
-
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -35,20 +21,15 @@ class ViewController: UIViewController {
         // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
         BugSplat.shared().set(NSDate().description, for: "ViewDidLoadDateTime")
 
-        // Add feedback input fields and button programmatically
+        // Add a "Send Feedback" button that presents a dialog
         let feedbackButton = UIButton(type: .system)
         feedbackButton.setTitle("Send Feedback", for: .normal)
-        feedbackButton.addTarget(self, action: #selector(sendFeedback), for: .touchUpInside)
-
-        let stack = UIStackView(arrangedSubviews: [titleField, descriptionField, feedbackButton])
-        stack.axis = .vertical
-        stack.spacing = 12
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(stack)
+        feedbackButton.addTarget(self, action: #selector(showFeedbackDialog), for: .touchUpInside)
+        feedbackButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(feedbackButton)
         NSLayoutConstraint.activate([
-            stack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            stack.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 40),
-            titleField.widthAnchor.constraint(equalToConstant: 280),
+            feedbackButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            feedbackButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 60)
         ])
     }
 
@@ -58,28 +39,31 @@ class ViewController: UIViewController {
         print(description)
     }
 
-    @objc func sendFeedback() {
-        guard let title = titleField.text, !title.isEmpty else { return }
-        let description = descriptionField.text
+    @objc func showFeedbackDialog() {
+        let alert = UIAlertController(title: "Send Feedback", message: nil, preferredStyle: .alert)
+        alert.addTextField { $0.placeholder = "Title" }
+        alert.addTextField { $0.placeholder = "Description" }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Send", style: .default) { _ in
+            guard let title = alert.textFields?[0].text, !title.isEmpty else { return }
+            let description = alert.textFields?[1].text
 
-        BugSplat.shared().postFeedback(
-            title: title,
-            description: description?.isEmpty == false ? description : nil,
-            userName: nil,
-            userEmail: nil,
-            appKey: nil,
-            attachments: nil
-        ) { error in
-            DispatchQueue.main.async { [weak self] in
+            BugSplat.shared().postFeedback(
+                title: title,
+                description: description?.isEmpty == false ? description : nil,
+                userName: nil,
+                userEmail: nil,
+                appKey: nil,
+                attachments: nil
+            ) { error in
                 if let error {
                     print("Feedback failed: \(error.localizedDescription)")
                 } else {
                     print("Feedback submitted successfully!")
-                    self?.titleField.text = ""
-                    self?.descriptionField.text = ""
                 }
             }
-        }
+        })
+        present(alert, animated: true)
     }
 
 }

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -12,6 +12,20 @@ import BugSplat
 class ViewController: UIViewController {
     var nonOptional: NSObject!
 
+    private let titleField: UITextField = {
+        let field = UITextField()
+        field.placeholder = "Feedback title"
+        field.borderStyle = .roundedRect
+        return field
+    }()
+
+    private let descriptionField: UITextField = {
+        let field = UITextField()
+        field.placeholder = "Description"
+        field.borderStyle = .roundedRect
+        return field
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -21,15 +35,20 @@ class ViewController: UIViewController {
         // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
         BugSplat.shared().set(NSDate().description, for: "ViewDidLoadDateTime")
 
-        // Add a "Send Feedback" button programmatically
+        // Add feedback input fields and button programmatically
         let feedbackButton = UIButton(type: .system)
         feedbackButton.setTitle("Send Feedback", for: .normal)
         feedbackButton.addTarget(self, action: #selector(sendFeedback), for: .touchUpInside)
-        feedbackButton.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(feedbackButton)
+
+        let stack = UIStackView(arrangedSubviews: [titleField, descriptionField, feedbackButton])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
         NSLayoutConstraint.activate([
-            feedbackButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            feedbackButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 60)
+            stack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stack.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 40),
+            titleField.widthAnchor.constraint(equalToConstant: 280),
         ])
     }
 
@@ -40,18 +59,25 @@ class ViewController: UIViewController {
     }
 
     @objc func sendFeedback() {
+        guard let title = titleField.text, !title.isEmpty else { return }
+        let description = descriptionField.text
+
         BugSplat.shared().postFeedback(
-            title: "User Feedback",
-            description: "This is a test feedback submission from the UIKit Swift example app.",
+            title: title,
+            description: description?.isEmpty == false ? description : nil,
             userName: nil,
             userEmail: nil,
             appKey: nil,
             attachments: nil
         ) { error in
-            if let error {
-                print("Feedback failed: \(error.localizedDescription)")
-            } else {
-                print("Feedback submitted successfully!")
+            DispatchQueue.main.async { [weak self] in
+                if let error {
+                    print("Feedback failed: \(error.localizedDescription)")
+                } else {
+                    print("Feedback submitted successfully!")
+                    self?.titleField.text = ""
+                    self?.descriptionField.text = ""
+                }
             }
         }
     }

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.hpp
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.hpp
@@ -13,6 +13,7 @@
 
 int bugSplatInit(const char * bugSplatDatabase);
 int bugSplatSetAttributeValue(std::string attribute, std::string value);
+int bugSplatSendFeedback(std::string title, std::string description);
 void mainObjCRunLoop();
 
 #endif /* BugSplatInit_hpp */

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
@@ -91,6 +91,42 @@ int bugSplatSetAttributeValue(std::string attribute, std::string value)
     return 0;
 }
 
+int bugSplatSendFeedback(std::string title, std::string description)
+{
+    @autoreleasepool {
+        NSString *titleString = @(title.c_str());
+        NSString *descriptionString = @(description.c_str());
+        NSLog(@"bugSplatSendFeedback(%@, %@)", titleString, descriptionString);
+
+        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+        __block NSError *feedbackError = nil;
+
+        [[BugSplat shared] postFeedback:titleString
+                            description:descriptionString
+                               userName:nil
+                              userEmail:nil
+                                 appKey:nil
+                            attachments:nil
+                             completion:^(NSError * _Nullable error) {
+            feedbackError = error;
+            dispatch_semaphore_signal(semaphore);
+        }];
+
+        // Give the run loop time to process the network request
+        while (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW)) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+        }
+
+        if (feedbackError) {
+            NSLog(@"Feedback failed: %@", feedbackError.localizedDescription);
+            return 1;
+        } else {
+            NSLog(@"Feedback submitted successfully!");
+            return 0;
+        }
+    }
+}
+
 void mainObjCRunLoop() {
     @autoreleasepool {
         // Objective-C often needs an NSRunLoop

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/main.cpp
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/main.cpp
@@ -21,6 +21,17 @@ int setAttributeAndValue()
     return bugSplatSetAttributeValue(attribute, value);
 }
 
+int sendFeedback()
+{
+    std::string title, description;
+    std::cout << "Enter feedback title: ";
+    std::getline(std::cin, title);
+    std::cout << "Enter feedback description: ";
+    std::getline(std::cin, description);
+
+    return bugSplatSendFeedback(title, description);
+}
+
 int checkInput(std::string input)
 {
     std::cout << "checkInput called: " << input << std::endl;
@@ -43,9 +54,13 @@ int checkInput(std::string input)
     {
         return setAttributeAndValue();
     }
+    else if (input == "feedback")
+    {
+        return sendFeedback();
+    }
     else
     {
-        std::cout << "Unknown command. Try: 'seg fault', 'divide by zero', 'set', or 'q' to quit" << std::endl;
+        std::cout << "Unknown command. Try: 'seg fault', 'divide by zero', 'set', 'feedback', or 'q' to quit" << std::endl;
     }
 
     return 0;

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -8,11 +8,6 @@
 #import "ViewController.h"
 #import <BugSplatMac/BugSplatMac.h>
 
-@interface ViewController ()
-@property (nonatomic, strong) NSTextField *titleField;
-@property (nonatomic, strong) NSTextField *descriptionField;
-@end
-
 @implementation ViewController
 
 - (void)viewDidLoad {
@@ -23,28 +18,17 @@
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"DateAndTime"];
 
-    // Add feedback input fields and button programmatically
-    self.titleField = [[NSTextField alloc] initWithFrame:NSZeroRect];
-    self.titleField.placeholderString = @"Feedback title";
-
-    self.descriptionField = [[NSTextField alloc] initWithFrame:NSZeroRect];
-    self.descriptionField.placeholderString = @"Description";
-
+    // Add a "Send Feedback" button that presents a dialog
     NSButton *feedbackButton = [[NSButton alloc] initWithFrame:NSZeroRect];
     feedbackButton.title = @"Send Feedback";
     feedbackButton.bezelStyle = NSBezelStyleRounded;
     feedbackButton.target = self;
-    feedbackButton.action = @selector(sendFeedback:);
-
-    NSStackView *stack = [NSStackView stackViewWithViews:@[self.titleField, self.descriptionField, feedbackButton]];
-    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
-    stack.spacing = 8;
-    stack.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:stack];
+    feedbackButton.action = @selector(showFeedbackDialog:);
+    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:feedbackButton];
     [NSLayoutConstraint activateConstraints:@[
-        [stack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-        [stack.topAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:30],
-        [self.titleField.widthAnchor constraintEqualToConstant:280],
+        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40]
     ]];
 }
 
@@ -60,28 +44,46 @@
     assert(NO);
 }
 
-- (IBAction)sendFeedback:(id)sender {
-    NSString *title = self.titleField.stringValue;
-    if (title.length == 0) return;
-    NSString *description = self.descriptionField.stringValue.length > 0 ? self.descriptionField.stringValue : nil;
+- (IBAction)showFeedbackDialog:(id)sender {
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = @"Send Feedback";
+    alert.informativeText = @"Enter your feedback below.";
+    [alert addButtonWithTitle:@"Send"];
+    [alert addButtonWithTitle:@"Cancel"];
 
-    [[BugSplat shared] postFeedback:title
-                        description:description
-                           userName:nil
-                          userEmail:nil
-                             appKey:nil
-                        attachments:nil
-                         completion:^(NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    NSTextField *titleField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 300, 22)];
+    titleField.placeholderString = @"Title";
+
+    NSTextField *descriptionField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 300, 22)];
+    descriptionField.placeholderString = @"Description";
+
+    NSStackView *stack = [NSStackView stackViewWithViews:@[titleField, descriptionField]];
+    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    stack.spacing = 8;
+    [titleField.widthAnchor constraintEqualToConstant:300].active = YES;
+
+    alert.accessoryView = stack;
+    [alert.window setInitialFirstResponder:titleField];
+
+    if ([alert runModal] == NSAlertFirstButtonReturn) {
+        NSString *title = titleField.stringValue;
+        if (title.length == 0) return;
+        NSString *description = descriptionField.stringValue.length > 0 ? descriptionField.stringValue : nil;
+
+        [[BugSplat shared] postFeedback:title
+                            description:description
+                               userName:nil
+                              userEmail:nil
+                                 appKey:nil
+                            attachments:nil
+                             completion:^(NSError * _Nullable error) {
             if (error) {
                 NSLog(@"Feedback failed: %@", error.localizedDescription);
             } else {
                 NSLog(@"Feedback submitted successfully!");
-                self.titleField.stringValue = @"";
-                self.descriptionField.stringValue = @"";
             }
-        });
-    }];
+        }];
+    }
 }
 
 @end

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -77,11 +77,13 @@
                                  appKey:nil
                             attachments:nil
                              completion:^(NSError * _Nullable error) {
-            if (error) {
-                NSLog(@"Feedback failed: %@", error.localizedDescription);
-            } else {
-                NSLog(@"Feedback submitted successfully!");
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSAlert *confirm = [[NSAlert alloc] init];
+                confirm.messageText = error ? @"Feedback Failed" : @"Feedback Sent";
+                confirm.informativeText = error ? error.localizedDescription : @"Your feedback was submitted successfully!";
+                [confirm addButtonWithTitle:@"OK"];
+                [confirm runModal];
+            });
         }];
     }
 }

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -47,7 +47,6 @@
 - (IBAction)showFeedbackDialog:(id)sender {
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = @"Send Feedback";
-    alert.informativeText = @"Enter your feedback below.";
     [alert addButtonWithTitle:@"Send"];
     [alert addButtonWithTitle:@"Cancel"];
 
@@ -57,10 +56,11 @@
     NSTextField *descriptionField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 300, 22)];
     descriptionField.placeholderString = @"Description";
 
-    NSStackView *stack = [NSStackView stackViewWithViews:@[titleField, descriptionField]];
+    NSStackView *stack = [[NSStackView alloc] initWithFrame:NSMakeRect(0, 0, 300, 52)];
     stack.orientation = NSUserInterfaceLayoutOrientationVertical;
     stack.spacing = 8;
-    [titleField.widthAnchor constraintEqualToConstant:300].active = YES;
+    [stack addArrangedSubview:titleField];
+    [stack addArrangedSubview:descriptionField];
 
     alert.accessoryView = stack;
     [alert.window setInitialFirstResponder:titleField];

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -8,6 +8,11 @@
 #import "ViewController.h"
 #import <BugSplatMac/BugSplatMac.h>
 
+@interface ViewController ()
+@property (nonatomic, strong) NSTextField *titleField;
+@property (nonatomic, strong) NSTextField *descriptionField;
+@end
+
 @implementation ViewController
 
 - (void)viewDidLoad {
@@ -18,17 +23,28 @@
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"DateAndTime"];
 
-    // Add a "Send Feedback" button programmatically
+    // Add feedback input fields and button programmatically
+    self.titleField = [[NSTextField alloc] initWithFrame:NSZeroRect];
+    self.titleField.placeholderString = @"Feedback title";
+
+    self.descriptionField = [[NSTextField alloc] initWithFrame:NSZeroRect];
+    self.descriptionField.placeholderString = @"Description";
+
     NSButton *feedbackButton = [[NSButton alloc] initWithFrame:NSZeroRect];
     feedbackButton.title = @"Send Feedback";
     feedbackButton.bezelStyle = NSBezelStyleRounded;
     feedbackButton.target = self;
     feedbackButton.action = @selector(sendFeedback:);
-    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:feedbackButton];
+
+    NSStackView *stack = [NSStackView stackViewWithViews:@[self.titleField, self.descriptionField, feedbackButton]];
+    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    stack.spacing = 8;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:stack];
     [NSLayoutConstraint activateConstraints:@[
-        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
-        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40]
+        [stack.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [stack.topAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:30],
+        [self.titleField.widthAnchor constraintEqualToConstant:280],
     ]];
 }
 
@@ -45,18 +61,26 @@
 }
 
 - (IBAction)sendFeedback:(id)sender {
-    [[BugSplat shared] postFeedback:@"User Feedback"
-                        description:@"This is a test feedback submission from the macOS ObjC example app."
+    NSString *title = self.titleField.stringValue;
+    if (title.length == 0) return;
+    NSString *description = self.descriptionField.stringValue.length > 0 ? self.descriptionField.stringValue : nil;
+
+    [[BugSplat shared] postFeedback:title
+                        description:description
                            userName:nil
                           userEmail:nil
                              appKey:nil
                         attachments:nil
                          completion:^(NSError * _Nullable error) {
-        if (error) {
-            NSLog(@"Feedback failed: %@", error.localizedDescription);
-        } else {
-            NSLog(@"Feedback submitted successfully!");
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error) {
+                NSLog(@"Feedback failed: %@", error.localizedDescription);
+            } else {
+                NSLog(@"Feedback submitted successfully!");
+                self.titleField.stringValue = @"";
+                self.descriptionField.stringValue = @"";
+            }
+        });
     }];
 }
 

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -17,6 +17,19 @@
     // Attributes can be set any time and can contain dynamic values
     // Attributes set in this app session will only appear if the app session in which they are set terminates with an app crash
     [[BugSplat shared] setValue:[[NSDate now] description] forAttribute:@"DateAndTime"];
+
+    // Add a "Send Feedback" button programmatically
+    NSButton *feedbackButton = [[NSButton alloc] initWithFrame:NSZeroRect];
+    feedbackButton.title = @"Send Feedback";
+    feedbackButton.bezelStyle = NSBezelStyleRounded;
+    feedbackButton.target = self;
+    feedbackButton.action = @selector(sendFeedback:);
+    feedbackButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:feedbackButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40]
+    ]];
 }
 
 
@@ -29,6 +42,22 @@
 - (IBAction)crashApp:(id)sender {
     NSLog(@"crashApp called from touch!");
     assert(NO);
+}
+
+- (IBAction)sendFeedback:(id)sender {
+    [[BugSplat shared] postFeedback:@"User Feedback"
+                        description:@"This is a test feedback submission from the macOS ObjC example app."
+                           userName:nil
+                          userEmail:nil
+                             appKey:nil
+                        attachments:nil
+                         completion:^(NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"Feedback failed: %@", error.localizedDescription);
+        } else {
+            NSLog(@"Feedback submitted successfully!");
+        }
+    }];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -264,6 +264,49 @@ Put another way, attributes and their values are only valid for the lifetime of 
 
 Please take a look at the framework-specific [sample applications](#sample-applications-) for more examples showing how to use attributes.
 
+### User Feedback
+
+BugSplat supports submitting user feedback (non-crash reports) from your application. Feedback is uploaded using crash type ID 36 (`User.Feedback`) and appears in the BugSplat dashboard alongside crash reports.
+
+**Swift:**
+
+```swift
+BugSplat.shared().postFeedback(
+    title: "Login button unresponsive",
+    description: "The login button doesn't respond on the first tap.",
+    userName: nil,
+    userEmail: nil,
+    appKey: nil,
+    attachments: nil
+) { error in
+    if let error {
+        print("Feedback failed: \(error.localizedDescription)")
+    } else {
+        print("Feedback submitted successfully!")
+    }
+}
+```
+
+**Obj-C:**
+
+```objc
+[[BugSplat shared] postFeedback:@"Login button unresponsive"
+                    description:@"The login button doesn't respond on the first tap."
+                       userName:nil
+                      userEmail:nil
+                         appKey:nil
+                    attachments:nil
+                     completion:^(NSError * _Nullable error) {
+    if (error) {
+        NSLog(@"Feedback failed: %@", error.localizedDescription);
+    } else {
+        NSLog(@"Feedback submitted successfully!");
+    }
+}];
+```
+
+All parameters except `title` are optional. When `userName`, `userEmail`, or `appKey` are nil, BugSplat falls back to the corresponding property values set on the `BugSplat` singleton. You can also include file attachments using an array of `BugSplatAttachment` objects.
+
 ### Crash Reporter Customization
 
 There are several ways to customize your BugSplat crash reporter.

--- a/Tests/BugSplatTests/BugSplatUploadServiceTests.m
+++ b/Tests/BugSplatTests/BugSplatUploadServiceTests.m
@@ -538,4 +538,303 @@
     XCTAssertEqualObjects(metadata.crashTime, @"2024-01-15T10:30:00Z");
 }
 
+#pragma mark - Feedback Upload Tests
+
+- (void)testUploadFeedback_SuccessfulFlow
+{
+    // Queue responses for the 3-step flow
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.amazonaws.com/bucket/key?signature=abc"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    NSDictionary *commitResponse = @{@"status": @"success"};
+    NSData *commitData = [NSJSONSerialization dataWithJSONObject:commitResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:commitData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Test Feedback"
+                           description:@"A test description"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    XCTAssertEqual(self.mockSession.requestCount, 3);
+}
+
+- (void)testUploadFeedback_SetsCrashTypeId36
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // Verify commit request contains crashTypeId=36 and crashType=User.Feedback
+    MockURLSessionRequest *commitRequest = self.mockSession.recordedRequests[2];
+    NSString *bodyString = [[NSString alloc] initWithData:commitRequest.request.HTTPBody encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([bodyString containsString:@"crashTypeId"]);
+    XCTAssertTrue([bodyString containsString:@"36"]);
+    XCTAssertTrue([bodyString containsString:@"User.Feedback"]);
+}
+
+- (void)testUploadFeedback_S3UploadContainsZipData
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // Second request (S3 upload) should contain ZIP data (PK magic number)
+    MockURLSessionRequest *s3Request = self.mockSession.recordedRequests[1];
+    XCTAssertTrue(s3Request.isUploadTask);
+    XCTAssertEqualObjects(s3Request.request.HTTPMethod, @"PUT");
+    const uint8_t *bytes = s3Request.bodyData.bytes;
+    XCTAssertEqual(bytes[0], 'P');
+    XCTAssertEqual(bytes[1], 'K');
+}
+
+- (void)testUploadFeedback_FailsWithEmptyTitle
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback fails"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+
+    [self.uploadService uploadFeedback:@""
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertTrue([error.localizedDescription containsString:@"title"]);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    XCTAssertEqual(self.mockSession.requestCount, 0);
+}
+
+- (void)testUploadFeedback_FailsWithNilTitle
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback fails"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+
+    [self.uploadService uploadFeedback:nil
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    XCTAssertEqual(self.mockSession.requestCount, 0);
+}
+
+- (void)testUploadFeedback_NilCompletionStillUploads
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    // Passing nil completion should not crash and should still upload
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:nil];
+
+    // Give async work time to complete
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(self.mockSession.requestCount, 3);
+}
+
+- (void)testUploadFeedback_PresignedURLFailure
+{
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:500]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback fails"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testUploadFeedback_WithAttachments
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    NSData *attachmentData = [@"log file content" dataUsingEncoding:NSUTF8StringEncoding];
+    BugSplatAttachment *attachment = [[BugSplatAttachment alloc] initWithFilename:@"log.txt"
+                                                                   attachmentData:attachmentData
+                                                                      contentType:@"text/plain"];
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:@[attachment]
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // Verify ZIP was uploaded (should contain both feedback.json and log.txt)
+    MockURLSessionRequest *s3Request = self.mockSession.recordedRequests[1];
+    XCTAssertTrue(s3Request.bodyData.length > 0);
+    const uint8_t *bytes = s3Request.bodyData.bytes;
+    XCTAssertEqual(bytes[0], 'P');
+    XCTAssertEqual(bytes[1], 'K');
+}
+
+- (void)testUploadFeedback_NilDescriptionIsAccepted
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title only"
+                           description:nil
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    XCTAssertEqual(self.mockSession.requestCount, 3);
+}
+
 @end


### PR DESCRIPTION
## Summary
- Adds `-[BugSplat postFeedback:description:userName:userEmail:appKey:attachments:completion:]` public API with `NS_SWIFT_NAME` for a clean Swift calling convention: `postFeedback(title:description:userName:userEmail:appKey:attachments:completion:)`
- Makes `crashTypeId` configurable on `BugSplatCrashMetadata`
- Adds `-[BugSplatUploadService uploadFeedback:description:attachments:metadata:completion:]` that creates `feedback.json`, zips it with optional attachments, and uploads via the 3-step presigned URL flow with `crashTypeId=36` (`User.Feedback`)
- Updates all 6 example apps to demonstrate the feedback API with native dialogs (SwiftUI `.alert`, `UIAlertController`, `NSAlert`)
- Documents the new API in the README with Swift and Obj-C examples
- Adds unit tests covering the feedback upload flow, title validation, nil completion handling, attachments, and error paths

## Test plan
- [x] Call `postFeedback(title:description:...)` with test database/app/version
- [x] Verify the report appears in BugSplat dashboard with crash type "User.Feedback"
- [x] Verify existing crash reporting still uses correct crashTypeId (13/macOS, 26/iOS)
- [x] Verify feedback submission works with nil completion handler
- [x] Verify empty/nil title returns a descriptive error
- [x] Verify file attachments are included in the feedback ZIP
- [x] Run unit tests (`BugSplatUploadServiceTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)