### PR TITLE
feat!: unify framework names and add CocoaPods support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ xcframeworks
 archives
 build/*
 Tools/symbol-upload-macos
+.build

--- a/BugSplat+Testing.h
+++ b/BugSplat+Testing.h
@@ -7,13 +7,7 @@
 //  Copyright © BugSplat, LLC. All rights reserved.
 //
 
-#import <TargetConditionals.h>
-
-#if TARGET_OS_OSX
-  #import <BugSplatMac/BugSplat.h>
-#else
-  #import <BugSplat/BugSplat.h>
-#endif
+#import <BugSplat/BugSplat.h>
 
 #import "BugSplatTestSupport.h"
 #import "BugSplatUploadService.h"

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -15,12 +15,10 @@ FOUNDATION_EXPORT const unsigned char BugSplatVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <BugSplat/PublicHeader.h>
 
+#import <BugSplat/BugSplatDelegate.h>
+#import <BugSplat/BugSplatAttachment.h>
 #if TARGET_OS_OSX
-  #import <BugSplatMac/BugSplatDelegate.h>
-  #import <BugSplatMac/BugSplatAttachment.h>
-#else
-  #import <BugSplat/BugSplatDelegate.h>
-  #import <BugSplat/BugSplatAttachment.h>
+#import <BugSplat/BugSplatMac.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -6,11 +6,7 @@
 
 #import <TargetConditionals.h>
 
-#if TARGET_OS_OSX
-#import <BugSplatMac/BugSplat.h>
-#else
 #import <BugSplat/BugSplat.h>
-#endif
 
 #import <CrashReporter/CrashReporter.h>
 #import "BugSplatUtilities.h"

--- a/BugSplat.podspec
+++ b/BugSplat.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name         = 'BugSplat'
+  s.version      = '2.0.0'
+  s.summary      = 'BugSplat crash reporting for iOS, macOS, and tvOS'
+  s.description  = <<-DESC
+    BugSplat is a crash reporting SDK for Apple platforms (iOS, macOS, tvOS).
+    It provides automatic crash reporting with PLCrashReporter statically linked.
+  DESC
+  s.homepage     = 'https://github.com/BugSplat-Git/bugsplat-apple'
+  s.license      = { type: 'MIT' }
+  s.author       = { 'BugSplat' => 'support@bugsplat.com' }
+  s.source       = { http: 'https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v2.0.0/BugSplat.xcframework.zip' }
+
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '11.5'
+  s.tvos.deployment_target = '13.0'
+
+  s.static_framework = true
+  s.vendored_frameworks = 'BugSplat.xcframework'
+  s.libraries = 'z', 'c++'
+end

--- a/BugSplat.podspec
+++ b/BugSplat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'BugSplat'
-  s.version      = '2.0.0'
+  s.version      = '3.0.0'
   s.summary      = 'BugSplat crash reporting for iOS, macOS, and tvOS'
   s.description  = <<-DESC
     BugSplat is a crash reporting SDK for Apple platforms (iOS, macOS, tvOS).
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/BugSplat-Git/bugsplat-apple'
   s.license      = { type: 'MIT' }
   s.author       = { 'BugSplat' => 'support@bugsplat.com' }
-  s.source       = { http: 'https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v2.0.0/BugSplat.xcframework.zip' }
+  s.source       = { http: 'https://github.com/BugSplat-Git/bugsplat-apple/releases/download/v3.0.0/BugSplat.xcframework.zip' }
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '11.5'

--- a/BugSplat.xcodeproj/project.pbxproj
+++ b/BugSplat.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		TT00000D2E3FE0000000000D /* BugSplatZipHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000142E3FA00000000014 /* BugSplatZipHelper.m */; };
 		TT00000E2E3FE0000000000E /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
 		TT00000F2E3FE0000000000F /* BugSplatUploadService.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000042E3FA00000000004 /* BugSplatUploadService.m */; };
-		TT0000202E3FE00000000020 /* BugSplatMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1ED2B92831A00AED3E3 /* BugSplatMac.framework */; };
+		TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */; };
 		TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
 /* Test target build files - iOS */
 		TT0000702E3FE00000000070 /* BugSplatUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */; };
@@ -112,7 +112,7 @@
 		637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatUtilities.h; sourceTree = "<group>"; };
 		637DF0472D49A50800DDD8FE /* BugSplatUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUtilities.m; sourceTree = "<group>"; };
 		63905E952D83912E009CDBEE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		63C6E1ED2B92831A00AED3E3 /* BugSplatMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplatMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63C6E1FC2B9283B000AED3E3 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63C6E1FE2B9283B000AED3E3 /* BugSplat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplat.h; sourceTree = "<group>"; };
 		63D006F92BBF785B00587FBF /* BugSplatMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatMac.h; sourceTree = "<group>"; };
@@ -124,7 +124,7 @@
 		AA0000122E3FA00000000012 /* BugSplatCrashReportWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatCrashReportWindow.h; sourceTree = "<group>"; };
 		AA0000142E3FA00000000014 /* BugSplatZipHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatZipHelper.m; sourceTree = "<group>"; };
 		AA0000172E3FA00000000017 /* BugSplatZipHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatZipHelper.h; sourceTree = "<group>"; };
-		BB0000002E3FB00000000000 /* BugSplatTV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplatTV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB0000002E3FB00000000000 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,9 +185,9 @@
 		63C6E1EE2B92831A00AED3E3 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				63C6E1ED2B92831A00AED3E3 /* BugSplatMac.framework */,
+				63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */,
 				63C6E1FC2B9283B000AED3E3 /* BugSplat.framework */,
-				BB0000002E3FB00000000000 /* BugSplatTV.framework */,
+				BB0000002E3FB00000000000 /* BugSplat.framework */,
 				TT0000002E3FE00000000000 /* BugSplatMacTests.xctest */,
 				TT0000802E3FE00000000080 /* BugSplatIOSTests.xctest */,
 			);
@@ -325,7 +325,7 @@
 			);
 			name = BugSplatMac;
 			productName = BugSplat;
-			productReference = 63C6E1ED2B92831A00AED3E3 /* BugSplatMac.framework */;
+			productReference = 63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		63C6E1FB2B9283B000AED3E3 /* BugSplat */ = {
@@ -360,8 +360,8 @@
 			dependencies = (
 			);
 			name = BugSplatTV;
-			productName = BugSplatTV;
-			productReference = BB0000002E3FB00000000000 /* BugSplatTV.framework */;
+			productName = BugSplat;
+			productReference = BB0000002E3FB00000000000 /* BugSplat.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		TT0000502E3FE00000000050 /* BugSplatMacTests */ = {
@@ -529,7 +529,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				TT0000202E3FE00000000020 /* BugSplatMac.framework in Frameworks */,
+				TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */,
 				TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -730,7 +730,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsplat.BugSplatMac;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = BugSplat;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = macosx;
@@ -769,7 +769,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsplat.BugSplatMac;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = BugSplat;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = macosx;
@@ -881,7 +881,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsplat.BugSplatTV;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = BugSplat;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -916,7 +916,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsplat.BugSplatTV;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = BugSplat;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatMac.xcscheme
+++ b/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatMac.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63C6E1EC2B92831A00AED3E3"
-               BuildableName = "BugSplatMac.framework"
+               BuildableName = "BugSplat.framework"
                BlueprintName = "BugSplatMac"
                ReferencedContainer = "container:BugSplat.xcodeproj">
             </BuildableReference>

--- a/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatMacTests.xcscheme
+++ b/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatMacTests.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63C6E1EC2B92831A00AED3E3"
-               BuildableName = "BugSplatMac.framework"
+               BuildableName = "BugSplat.framework"
                BlueprintName = "BugSplatMac"
                ReferencedContainer = "container:BugSplat.xcodeproj">
             </BuildableReference>

--- a/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatTV.xcscheme
+++ b/BugSplat.xcodeproj/xcshareddata/xcschemes/BugSplatTV.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BB0000152E3FB00000000015"
-               BuildableName = "BugSplatTV.framework"
+               BuildableName = "BugSplat.framework"
                BlueprintName = "BugSplatTV"
                ReferencedContainer = "container:BugSplat.xcodeproj">
             </BuildableReference>

--- a/BugSplatDelegate.h
+++ b/BugSplatDelegate.h
@@ -5,8 +5,7 @@
 //
 
 #import <TargetConditionals.h>
-
-#import <BugSplat/BugSplat.h>
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/BugSplatDelegate.h
+++ b/BugSplatDelegate.h
@@ -6,11 +6,7 @@
 
 #import <TargetConditionals.h>
 
-#if TARGET_OS_OSX
-  #import <BugSplatMac/BugSplatMac.h>
-#else
-  #import <BugSplat/BugSplat.h>
-#endif
+#import <BugSplat/BugSplat.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/BugSplatMac.h
+++ b/BugSplatMac.h
@@ -8,8 +8,8 @@
 #ifndef BugSplatMac_h
 #define BugSplatMac_h
 
-#import <BugSplatMac/BugSplat.h>
-#import <BugSplatMac/BugSplatDelegate.h>
-#import <BugSplatMac/BugSplatAttachment.h>
+#import <BugSplat/BugSplat.h>
+#import <BugSplat/BugSplatDelegate.h>
+#import <BugSplat/BugSplatAttachment.h>
 
 #endif /* BugSplatMac_h */

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		637DF0D92D72A8CA00DDD8FE /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 637DF0D72D72A69C00DDD8FE /* AppKit.framework */; };
-		637DF0E12D72B00000000002 /* BugSplatMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000005 /* BugSplatMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		WS0000012E40000000000004 /* BugSplatMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000005 /* BugSplatMac.framework */; };
+		637DF0E12D72B00000000002 /* BugSplat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000005 /* BugSplat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		WS0000012E40000000000004 /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000005 /* BugSplat.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,7 +28,7 @@
 			dstPath = ../Frameworks;
 			dstSubfolderSpec = 6;
 			files = (
-				637DF0E12D72B00000000002 /* BugSplatMac.framework in Embed Frameworks */,
+				637DF0E12D72B00000000002 /* BugSplat.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -38,7 +38,7 @@
 /* Begin PBXFileReference section */
 		637DF0622D6CE56800DDD8FE /* BugSplatTest-macOS-Tool-CPlusPlus */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "BugSplatTest-macOS-Tool-CPlusPlus"; sourceTree = BUILT_PRODUCTS_DIR; };
 		637DF0D72D72A69C00DDD8FE /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
-		WS0000022E40000000000005 /* BugSplatMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BugSplatMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		WS0000022E40000000000005 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				WS0000012E40000000000004 /* BugSplatMac.framework in Frameworks */,
+				WS0000012E40000000000004 /* BugSplat.framework in Frameworks */,
 				637DF0D92D72A8CA00DDD8FE /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -83,7 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				637DF0D72D72A69C00DDD8FE /* AppKit.framework */,
-				WS0000022E40000000000005 /* BugSplatMac.framework */,
+				WS0000022E40000000000005 /* BugSplat.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,7 +186,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Manually Codesign dependency frameworks. Team ID for cert must match app Team ID.\n# Path to your frameworks\nBUGSPLAT_PATH=\"${BUILT_PRODUCTS_DIR}/BugSplatMac.framework\"\n\n# Sign the frameworks\ncodesign --force --deep --sign \"Apple Distribution: BugSplat, LLC (TN6R4Q475K)\" \"$BUGSPLAT_PATH\"\n";
+			shellScript = "# Manually Codesign dependency frameworks. Team ID for cert must match app Team ID.\n# Path to your frameworks\nBUGSPLAT_PATH=\"${BUILT_PRODUCTS_DIR}/BugSplat.framework\"\n\n# Sign the frameworks\ncodesign --force --deep --sign \"Apple Distribution: BugSplat, LLC (TN6R4Q475K)\" \"$BUGSPLAT_PATH\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
@@ -8,7 +8,7 @@
 #include "BugSplatInit.hpp"
 
 #import <AppKit/AppKit.h> // for NSApplicationDidFinishLaunchingNotification
-#import <BugSplatMac/BugSplatMac.h>
+#import <BugSplat/BugSplat.h>
 
 @interface MyBugSplatDelegate : NSObject <BugSplatDelegate>
 

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/README.md
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/README.md
@@ -22,7 +22,7 @@ In the Example App BugSplatTest-macOS-Tool-CPlusPlus, BugSplatInit.mm contains b
 #include "BugSplatInit.hpp"
 
 #import <AppKit/AppKit.h> // for NSApplicationDidFinishLaunchingNotification
-#import <BugSplatMac/BugSplatMac.h>
+#import <BugSplat/BugSplat.h>
 
 @interface MyBugSplatDelegate : NSObject <BugSplatDelegate>
 @end

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		6341B27A2BDC4DEB007EE8AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6341B2792BDC4DEB007EE8AC /* Assets.xcassets */; };
 		6341B27D2BDC4DEB007EE8AC /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6341B27C2BDC4DEB007EE8AC /* Base */; };
 		6341B27F2BDC4DEB007EE8AC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6341B27E2BDC4DEB007EE8AC /* main.m */; };
-		WS0000012E40000000000001 /* BugSplatMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000002 /* BugSplatMac.framework */; };
-		WS0000032E40000000000003 /* BugSplatMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000002 /* BugSplatMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		WS0000012E40000000000001 /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000002 /* BugSplat.framework */; };
+		WS0000032E40000000000003 /* BugSplat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = WS0000022E40000000000002 /* BugSplat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -23,7 +23,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				WS0000032E40000000000003 /* BugSplatMac.framework in Embed Frameworks */,
+				WS0000032E40000000000003 /* BugSplat.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -41,7 +41,7 @@
 		6341B27E2BDC4DEB007EE8AC /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		6341B2802BDC4DEB007EE8AC /* BugSplatTest_macOS_UIKit_ObjC.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BugSplatTest_macOS_UIKit_ObjC.entitlements; sourceTree = "<group>"; };
 		636215F72BE0732900A21933 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		WS0000022E40000000000002 /* BugSplatMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BugSplatMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		WS0000022E40000000000002 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,7 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				WS0000012E40000000000001 /* BugSplatMac.framework in Frameworks */,
+				WS0000012E40000000000001 /* BugSplat.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,7 +92,7 @@
 		6341B2862BDC4E02007EE8AC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				WS0000022E40000000000002 /* BugSplatMac.framework */,
+				WS0000022E40000000000002 /* BugSplat.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/AppDelegate.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/AppDelegate.m
@@ -6,7 +6,7 @@
 //
 
 #import "AppDelegate.h"
-#import "BugSplatMac/BugSplatMac.h"
+#import "BugSplat/BugSplat.h"
 
 @interface AppDelegate () <BugSplatDelegate>
 

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -6,7 +6,7 @@
 //
 
 #import "ViewController.h"
-#import <BugSplatMac/BugSplatMac.h>
+#import <BugSplat/BugSplat.h>
 
 @implementation ViewController
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The BugSplat.xcframework enables posting crash reports from iOS, macOS, and Mac 
 
 The BugSplat crash reporting SDK can be integrated into your project via the following methods:
 - Using Swift Package Manager
+- Using CocoaPods
 - Manually adding xcframeworks
 
 ### Swift Package Manager (SPM)
@@ -34,6 +35,16 @@ Add the following URL to your project's `Additional Package Dependencies`:
 ```sh
 https://github.com/BugSplat-Git/bugsplat-apple
 ```
+
+### CocoaPods
+
+Add the following to your `Podfile`:
+
+```ruby
+pod 'BugSplat', '~> 3.0'
+```
+
+Then run `pod install`.
 
 ### Manually Add xcframeworks
 
@@ -198,7 +209,7 @@ struct BugSplatTestSwiftUIApp: App {
 #### Obj-C
 
 ```objc
-#import "BugSplatMac/BugSplatMac.h"
+#import <BugSplat/BugSplat.h>
 
 @interface AppDelegate () <BugSplatDelegate>
 @end
@@ -367,7 +378,7 @@ For macOS, the BugSplat crash dialogue can be localized and supports eight langu
 7. Norwegian
 8. Swedish
 
-Additional languages may be supported by adding the language bundle and strings file to `BugSplat.xcframework/macos-arm64_x86_64/BugSplatMac.framework/Versions/A/Resources/`
+Additional languages may be supported by adding the language bundle and strings file to `BugSplat.xcframework/macos-arm64_x86_64/BugSplat.framework/Versions/A/Resources/`
 
 ## Sample Applications 🧑‍🏫
 

--- a/Tests/BugSplatTests/BugSplatTests.m
+++ b/Tests/BugSplatTests/BugSplatTests.m
@@ -10,11 +10,7 @@
 #import <TargetConditionals.h>
 #import <XCTest/XCTest.h>
 
-#if TARGET_OS_OSX
-#import <BugSplatMac/BugSplat.h>
-#else
 #import <BugSplat/BugSplat.h>
-#endif
 
 #import "BugSplat+Testing.h"
 #import "BugSplatTestSupport.h"

--- a/makeXCFramework.sh
+++ b/makeXCFramework.sh
@@ -21,34 +21,35 @@ fi
 # Build PLCrashReporter if xcframework doesn't exist
 if [ ! -d "$PLCRASHREPORTER_XCFRAMEWORK" ]; then
     echo "Building PLCrashReporter with BugSplat namespace prefix..."
-    
+
     cd "$PLCRASHREPORTER_DIR"
-    
-    # Build for each platform
+
+    # Build for each platform as static frameworks (MACH_O_TYPE=staticlib)
+    # so CrashReporter is statically linked into BugSplat.framework
     echo "  Building iOS device..."
     xcodebuild -scheme "CrashReporter iOS Framework" -configuration Release -sdk iphoneos \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO -quiet
-    
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO MACH_O_TYPE=staticlib -quiet
+
     echo "  Building iOS simulator..."
     xcodebuild -scheme "CrashReporter iOS Framework" -configuration Release -sdk iphonesimulator \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO -quiet
-    
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO MACH_O_TYPE=staticlib -quiet
+
     echo "  Building macOS..."
     xcodebuild -scheme "CrashReporter macOS Framework" -configuration Release \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO -quiet
-    
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO MACH_O_TYPE=staticlib -quiet
+
     echo "  Building tvOS device..."
     xcodebuild -scheme "CrashReporter tvOS Framework" -configuration Release -sdk appletvos \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO -quiet
-    
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO MACH_O_TYPE=staticlib -quiet
+
     echo "  Building tvOS simulator..."
     xcodebuild -scheme "CrashReporter tvOS Framework" -configuration Release -sdk appletvsimulator \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO -quiet
-    
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES SKIP_INSTALL=NO MACH_O_TYPE=staticlib -quiet
+
     # Find the DerivedData path
     DERIVED_DATA=$(xcodebuild -scheme "CrashReporter iOS Framework" -configuration Release -sdk iphoneos -showBuildSettings 2>/dev/null | grep -m 1 "BUILD_DIR" | awk '{print $3}' | sed 's|/Build/Products||')
     PRODUCTS_DIR="$DERIVED_DATA/Build/Products"
-    
+
     echo "  Creating CrashReporter.xcframework..."
     xcodebuild -create-xcframework \
         -framework "$PRODUCTS_DIR/Release-iphoneos/CrashReporter.framework" \
@@ -57,7 +58,7 @@ if [ ! -d "$PLCRASHREPORTER_XCFRAMEWORK" ]; then
         -framework "$PRODUCTS_DIR/Release-appletvos/CrashReporter.framework" \
         -framework "$PRODUCTS_DIR/Release-appletvsimulator/CrashReporter.framework" \
         -output "$PLCRASHREPORTER_XCFRAMEWORK"
-    
+
     echo "PLCrashReporter.xcframework built successfully!"
     cd "$SCRIPT_DIR"
 else

--- a/makeXCFramework.sh
+++ b/makeXCFramework.sh
@@ -96,9 +96,9 @@ echo "Creating xcframeworks/BugSplat.xcframework..."
 xcodebuild -create-xcframework \
     -archive archives/BugSplat-iOS.xcarchive -framework BugSplat.framework \
     -archive archives/BugSplat-iOS_Simulator.xcarchive -framework BugSplat.framework \
-    -archive archives/BugSplat-macOS.xcarchive -framework BugSplatMac.framework \
-    -archive archives/BugSplat-tvOS.xcarchive -framework BugSplatTV.framework \
-    -archive archives/BugSplat-tvOS_Simulator.xcarchive -framework BugSplatTV.framework \
+    -archive archives/BugSplat-macOS.xcarchive -framework BugSplat.framework \
+    -archive archives/BugSplat-tvOS.xcarchive -framework BugSplat.framework \
+    -archive archives/BugSplat-tvOS_Simulator.xcarchive -framework BugSplat.framework \
     -output xcframeworks/BugSplat.xcframework
 
 echo "Done! xcframeworks/BugSplat.xcframework created."


### PR DESCRIPTION
## Summary

- **Unified framework product names** across all platforms: macOS (`BugSplatMac` → `BugSplat`) and tvOS (`BugSplatTV` → `BugSplat`). All platform slices now produce `BugSplat.framework`.
- **Added CocoaPods support** with a new `BugSplat.podspec` (v3.0.0) that distributes the pre-built xcframework via HTTP source.
- **Updated all header imports** to use `<BugSplat/...>` unconditionally, removing `#if TARGET_OS_OSX` conditionals.
- **Updated README** with CocoaPods integration instructions, fixed Obj-C example import, and corrected localization path.

## Why

The xcframework previously contained different framework names per platform (`BugSplat.framework` for iOS, `BugSplatMac.framework` for macOS, `BugSplatTV.framework` for tvOS). CocoaPods requires consistent framework names across all xcframework slices — the macOS and tvOS `pod spec lint` builds failed because the linker looked for `BugSplat.framework` but found `BugSplatMac.framework`/`BugSplatTV.framework`. Unifying the names unblocks CocoaPods publishing, which is needed for `bugsplat-expo` integration.

## Breaking changes

The macOS/tvOS module name changes from `BugSplatMac`/`BugSplatTV` to `BugSplat`:
- `#import <BugSplatMac/BugSplatMac.h>` → `#import <BugSplat/BugSplat.h>`
- `@import BugSplatMac` → `@import BugSplat`
- SPM users are **unaffected** (`import BugSplat` already worked)

## Test plan

- [x] **iOS build**: Build the `BugSplat` scheme for iOS — verify `BugSplat.framework` is produced and the build succeeds
- [x] **macOS build**: Build the `BugSplatMac` scheme for macOS — verify `BugSplat.framework` (not `BugSplatMac.framework`) is produced
- [x] **tvOS build**: Build the `BugSplatTV` scheme for tvOS — verify `BugSplat.framework` (not `BugSplatTV.framework`) is produced
- [x] **macOS tests**: Run `BugSplatMacTests` scheme — all tests should pass
- [x] **iOS tests**: Run `BugSplatIOSTests` scheme — all tests should pass
- [x] **XCFramework build**: Run `./makeXCFramework.sh` and verify the output xcframework contains `BugSplat.framework` for all platform slices (check `BugSplat.xcframework/*/` directories)
- [ ] **SPM integration**: Add the package via SPM in a clean project, `import BugSplat`, and verify it builds for iOS and macOS
- [ ] **CocoaPods lint**: After the v3.0.0 release is published, run `pod spec lint BugSplat.podspec --allow-warnings` and verify it passes
- [x] **Example apps**: Build the macOS example apps (`BugSplatTest-macOS-UIKit-ObjC`, `BugSplatTest-macOS-Tool-CPlusPlus`) — verify they compile with the updated `#import <BugSplat/BugSplat.h>` imports

## Post-merge steps

1. CI should detect `feat!:` and create a v3.0.0 release with the new xcframework
2. Register with CocoaPods trunk (one-time): `pod trunk register support@bugsplat.com 'BugSplat'`
3. Publish: `pod trunk push BugSplat.podspec --allow-warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)