### PR TITLE
fix: disable crash reporter when debugger is attached

### DIFF
--- a/BugSplat+Testing.h
+++ b/BugSplat+Testing.h
@@ -77,6 +77,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<BugSplatCrashStorageProtocol>)crashStorage;
 
+/**
+ * Override debugger detection for testing.
+ * Pass @YES to simulate debugger attached, @NO to simulate no debugger, nil to use real detection.
+ */
+- (void)setDebuggerAttachedOverride:(nullable NSNumber *)value;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -74,6 +74,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     NSString *_bugSplatDatabase;
     NSString *_applicationName;
     NSString *_applicationVersion;
+    NSNumber *_debuggerAttachedOverride;
 }
 
 + (instancetype)shared
@@ -88,8 +89,12 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     return sharedInstance;
 }
 
-+ (BOOL)isDebuggerAttached
+- (BOOL)isDebuggerAttached
 {
+    if (_debuggerAttachedOverride != nil) {
+        return [_debuggerAttachedOverride boolValue];
+    }
+
     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
     struct kinfo_proc info = {0};
     size_t size = sizeof(info);
@@ -225,7 +230,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     // When a debugger is attached, PLCrashReporter's Mach exception handler conflicts
     // with LLDB's exception ports, causing SIGTRAP (signal 5) termination.
     // Skip enabling the crash reporter but still process pending crashes above.
-    if ([BugSplat isDebuggerAttached]) {
+    if ([self isDebuggerAttached]) {
         NSLog(@"BugSplat: Debugger attached - crash reporting disabled for this session");
         self.isStartInvoked = YES;
         return;
@@ -1546,6 +1551,11 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 - (id<BugSplatCrashStorageProtocol>)crashStorage
 {
     return self.crashStorageInternal;
+}
+
+- (void)setDebuggerAttachedOverride:(NSNumber *)value
+{
+    _debuggerAttachedOverride = value;
 }
 
 @end

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -185,7 +185,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     // with LLDB's exception ports, causing SIGTRAP (signal 5) termination. Since crash
     // reporting isn't useful during debugging, skip enabling it entirely.
     if ([BugSplat isDebuggerAttached]) {
-        NSLog(@"BugSplat: Debugger attached — crash reporting disabled");
+        NSLog(@"BugSplat: Debugger attached - crash reporting disabled");
         return;
     }
 

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -12,6 +12,7 @@
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#include <unistd.h>
 #import "BugSplatUtilities.h"
 #import "BugSplatUploadService.h"
 #import "BugSplatZipHelper.h"
@@ -90,11 +91,12 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 + (BOOL)isDebuggerAttached
 {
     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
-    struct kinfo_proc info;
+    struct kinfo_proc info = {0};
     size_t size = sizeof(info);
 
     if (sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0) != 0) {
-        return NO;
+        NSLog(@"BugSplat: Failed to query debugger status via sysctl; assuming debugger is attached");
+        return YES;
     }
 
     return (info.kp_proc.p_flag & P_TRACED) != 0;
@@ -181,14 +183,6 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 {
     NSLog(@"BugSplat start...");
 
-    // When a debugger is attached, PLCrashReporter's Mach exception handler conflicts
-    // with LLDB's exception ports, causing SIGTRAP (signal 5) termination. Since crash
-    // reporting isn't useful during debugging, skip enabling it entirely.
-    if ([BugSplat isDebuggerAttached]) {
-        NSLog(@"BugSplat: Debugger attached - crash reporting disabled");
-        return;
-    }
-
     // Debug: Check what bundle and info dictionary we're reading from
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSLog(@"BugSplat: mainBundle = %@", mainBundle);
@@ -228,17 +222,26 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     // This includes both new crashes and previously failed uploads
     [self processPendingCrashReports];
     
+    // When a debugger is attached, PLCrashReporter's Mach exception handler conflicts
+    // with LLDB's exception ports, causing SIGTRAP (signal 5) termination.
+    // Skip enabling the crash reporter but still process pending crashes above.
+    if ([BugSplat isDebuggerAttached]) {
+        NSLog(@"BugSplat: Debugger attached - crash reporting disabled for this session");
+        self.isStartInvoked = YES;
+        return;
+    }
+
     // Set crash-time metadata on PLCrashReporter BEFORE enabling it
     // If a crash occurs, this metadata will be saved WITH the crash report
     [self updateCrashReporterCustomData];
-    
+
     // Enable crash reporter for this session
     NSError *error = nil;
     if (![self.crashReporter enableCrashReporterAndReturnError:&error]) {
         NSLog(@"BugSplat: Failed to enable crash reporter: %@", error);
         return;
     }
-    
+
     self.isStartInvoked = YES;
 }
 

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -9,6 +9,9 @@
 #import <BugSplat/BugSplat.h>
 
 #import <CrashReporter/CrashReporter.h>
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
 #import "BugSplatUtilities.h"
 #import "BugSplatUploadService.h"
 #import "BugSplatZipHelper.h"
@@ -84,6 +87,19 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     return sharedInstance;
 }
 
++ (BOOL)isDebuggerAttached
+{
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+    struct kinfo_proc info;
+    size_t size = sizeof(info);
+
+    if (sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0) != 0) {
+        return NO;
+    }
+
+    return (info.kp_proc.p_flag & P_TRACED) != 0;
+}
+
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -102,7 +118,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
         PLCrashReporterConfig *config = [[PLCrashReporterConfig alloc]
             initWithSignalHandlerType:signalHandlerType
             symbolicationStrategy:PLCrashReporterSymbolicationStrategyNone];
-        
+
         _crashReporterInternal = (id<BugSplatCrashReporterProtocol>)[[PLCrashReporter alloc] initWithConfiguration:config];
         
         // Use real defaults by default
@@ -164,7 +180,15 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 - (void)start
 {
     NSLog(@"BugSplat start...");
-    
+
+    // When a debugger is attached, PLCrashReporter's Mach exception handler conflicts
+    // with LLDB's exception ports, causing SIGTRAP (signal 5) termination. Since crash
+    // reporting isn't useful during debugging, skip enabling it entirely.
+    if ([BugSplat isDebuggerAttached]) {
+        NSLog(@"BugSplat: Debugger attached — crash reporting disabled");
+        return;
+    }
+
     // Debug: Check what bundle and info dictionary we're reading from
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSLog(@"BugSplat: mainBundle = %@", mainBundle);

--- a/Tests/BugSplatTests/BugSplatTests.m
+++ b/Tests/BugSplatTests/BugSplatTests.m
@@ -403,4 +403,39 @@
     XCTAssertNil(self.bugSplat.delegate);
 }
 
+#pragma mark - Debugger Detection Tests
+
+- (void)testStart_SkipsCrashReporterWhenDebuggerAttached
+{
+    [self.bugSplat setDebuggerAttachedOverride:@YES];
+    [self.bugSplat start];
+
+    XCTAssertTrue([self.bugSplat isStartInvoked]);
+    XCTAssertFalse(self.mockCrashReporter.wasEnabled);
+}
+
+- (void)testStart_EnablesCrashReporterWhenNoDebugger
+{
+    [self.bugSplat setDebuggerAttachedOverride:@NO];
+    [self.bugSplat start];
+
+    XCTAssertTrue([self.bugSplat isStartInvoked]);
+    XCTAssertTrue(self.mockCrashReporter.wasEnabled);
+}
+
+- (void)testStart_ProcessesPendingCrashesEvenWithDebugger
+{
+    // Set up a pending crash report
+    NSData *fakeCrashData = [@"fake crash" dataUsingEncoding:NSUTF8StringEncoding];
+    self.mockCrashReporter.hasPendingReport = YES;
+    self.mockCrashReporter.pendingCrashReportData = fakeCrashData;
+
+    [self.bugSplat setDebuggerAttachedOverride:@YES];
+    [self.bugSplat start];
+
+    // Pending report should still be purged (processed) even with debugger attached
+    XCTAssertTrue(self.mockCrashReporter.wasPurged);
+    XCTAssertFalse(self.mockCrashReporter.wasEnabled);
+}
+
 @end


### PR DESCRIPTION
## Summary
- PLCrashReporter's Mach exception handler conflicts with LLDB's exception ports, causing immediate SIGTRAP (signal 5) termination when running iOS samples with the Xcode debugger attached
- Added `isDebuggerAttached` check using `sysctl` `P_TRACED` flag to detect LLDB
- When a debugger is detected, `start` returns early and skips crash reporter setup entirely, since crash reporting isn't useful during debugging

## Test plan
- [x] Run iOS sample app with debugger attached — app no longer crashes with signal 5
- [x] Run iOS sample app without debugger — crash reporting works as before
- [x] Verified build succeeds with `xcodebuild`

🤖 Generated with [Claude Code](https://claude.com/claude-code)