### PR TITLE
chore: add macOS dylib to release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,10 @@ jobs:
         # Create zip archive
         cd xcframeworks
         zip -y -r BugSplat.xcframework.zip BugSplat.xcframework
+
+        # Extract macOS dylib for game engine integration (e.g., Unity)
+        cp BugSplat.xcframework/macos-arm64_x86_64/BugSplat.framework/Versions/A/BugSplat BugSplat-macOS.dylib
+        install_name_tool -id "@rpath/BugSplat-macOS.dylib" BugSplat-macOS.dylib
         
     - name: Update Package.swift
       run: |
@@ -113,6 +117,7 @@ jobs:
         tag_name: ${{ needs.check-version.outputs.next }}
         files: |
           xcframeworks/BugSplat.xcframework.zip
+          xcframeworks/BugSplat-macOS.dylib
         name: Release ${{ needs.check-version.outputs.next }}
         body: |
           Release of BugSplat.xcframework version ${{ needs.check-version.outputs.next }}
@@ -130,8 +135,12 @@ jobs:
           ```
           
           ## Manual Integration
-          
+
           Download `BugSplat.xcframework.zip`, unzip, and add to your Xcode project.
+
+          ## Game Engine Integration (Unity, etc.)
+
+          Download `BugSplat-macOS.dylib` for macOS native plugin integration.
         draft: false
         prerelease: false
       env:


### PR DESCRIPTION
## Summary
- Extract `BugSplat-macOS.dylib` from the xcframework's macOS slice during CI
- Fix install name to `@rpath/BugSplat-macOS.dylib`
- Include as a release artifact alongside the xcframework zip

## Why
Game engines like Unity need a bare `.dylib` for macOS native plugin integration. Unity's plugin system reliably copies `.dylib` files to build output but doesn't handle `.framework` bundles or `.xcframework` on macOS standalone builds.

## Changes
- `.github/workflows/release.yml` — extract dylib, fix install name, upload as release artifact, add docs to release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)