### PR TITLE
feat: fatal main-thread hang detection

### DIFF
--- a/BugSplat+Testing.h
+++ b/BugSplat+Testing.h
@@ -11,6 +11,7 @@
 
 #import "BugSplatTestSupport.h"
 #import "BugSplatUploadService.h"
+#import "BugSplatHangTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,11 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Class extension to expose private methods for testing.
  * These methods are implemented in the main BugSplat class.
  */
-@interface BugSplat ()
+@interface BugSplat () <BugSplatHangTrackerDelegate>
 
 - (BOOL)shouldSendCrashSilently:(NSDictionary *)metadata;
 - (NSString *)resolvedApplicationName;
 - (NSString *)resolvedApplicationVersion;
+- (nullable NSString *)crashesDirectoryPath;
 
 @end
 
@@ -82,6 +84,22 @@ NS_ASSUME_NONNULL_BEGIN
  * Pass @YES to simulate debugger attached, @NO to simulate no debugger, nil to use real detection.
  */
 - (void)setDebuggerAttachedOverride:(nullable NSNumber *)value;
+
+#pragma mark - Hang Detection Testing
+
+/**
+ * Create the internal plumbing (serial queue, launch id) that `-start` would
+ * normally set up for hang detection. Lets tests exercise the hang delegate
+ * methods without starting the real tracker or enabling the crash reporter.
+ */
+- (void)setupHangInfrastructureForTesting;
+
+/// Serial queue that hang delegate callbacks dispatch onto; `dispatch_sync` on
+/// this queue to wait for pending hang work to drain.
+- (nullable dispatch_queue_t)hangQueueForTesting;
+
+/// The basename of the hang report most recently persisted by the hang delegate.
+- (nullable NSString *)currentHangFilename;
 
 @end
 

--- a/BugSplat.h
+++ b/BugSplat.h
@@ -166,6 +166,49 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL autoSubmitCrashReport;
 
 /**
+ * Enable detection and reporting of fatal main-thread hangs.
+ *
+ * When set to YES before `-start` is invoked, BugSplat monitors the main runloop for
+ * prolonged unresponsive periods while the app is active in the foreground. If a hang
+ * is detected and the app is subsequently terminated without the main thread recovering
+ * (launch/resume watchdog kills, user force-quit), a hang report is uploaded on the next
+ * launch using the same pipeline as crash reports.
+ *
+ * If the main thread resumes after a hang is detected, the persisted report is discarded -
+ * non-fatal hangs are not reported in this version.
+ *
+ * Hang reports carry the exception name `App Hang (Fatal)` and include attributes prefixed
+ * with `bugsplat-hang-` (duration, detection time, app state, launch id) that can be used
+ * to correlate with crashes from the same launch.
+ *
+ * Detection is suppressed when a debugger is attached or the app is not active. As a
+ * consequence, hangs that begin while the app is in the background (including those
+ * terminated by background-task expiration) are not reported.
+ *
+ * This property is a no-op inside app extensions.
+ *
+ * When this property is YES, `-start` must be invoked on the main thread - the
+ * main thread's Mach port is captured there so the hang report identifies the
+ * correct thread. Debug builds assert; Release builds will silently capture the
+ * wrong thread.
+ *
+ * Default: NO
+ */
+@property (nonatomic, assign) BOOL enableHangDetection;
+
+/**
+ * Threshold in seconds for declaring the main thread hung when `enableHangDetection` is YES.
+ *
+ * Must be set before `-start` is invoked. Values below 0.1 are clamped to 0.1 by the
+ * underlying tracker. Typical production values are 1.0-5.0 seconds; choose a value above
+ * any work the app may legitimately do on the main thread (image decoding, JSON parsing,
+ * etc.) to avoid false positives.
+ *
+ * Default: 2.0
+ */
+@property (nonatomic, assign) NSTimeInterval hangDetectionThreshold;
+
+/**
  * Add an attribute and value to a dictionary of attributes that will potentially be included in a crash report.
  * If the attribute is an invalid XML entity name, or the attribute+value pair cannot be set,
  * the method will return NO, otherwise it will return YES.

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -491,8 +491,12 @@ didDetectHangWithDuration:(NSTimeInterval)duration
         return;
     }
 
+    // Use millisecond precision so a hang -> recover -> hang cycle inside the
+    // same second can't generate two reports with the same filename. Keeps
+    // monotonic sort order without introducing a separator that the existing
+    // path parsing would have to learn about.
     NSString *hangFilename = [NSString stringWithFormat:@"%.0f%@",
-                              [NSDate timeIntervalSinceReferenceDate],
+                              [NSDate timeIntervalSinceReferenceDate] * 1000.0,
                               kBugSplatHangFilenameSuffix];
 
     NSData *textData = [reportText dataUsingEncoding:NSUTF8StringEncoding];

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -13,11 +13,16 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <unistd.h>
+#include <pthread.h>
+#import <stdatomic.h>
+#import <mach/mach.h>
+
 #import "BugSplatUtilities.h"
 #import "BugSplatUploadService.h"
 #import "BugSplatZipHelper.h"
 #import "BugSplatTestSupport.h"
 #import "BugSplat+Testing.h"
+#import "BugSplatHangTracker.h"
 
 #if TARGET_OS_OSX
 #import "BugSplatCrashReportWindow.h"
@@ -35,6 +40,15 @@ static NSString *const kBugSplatCrashFileExtension = @"crash";
 static NSString *const kBugSplatMetaFileExtension = @"meta";
 static NSString *const kBugSplatAttachmentFileExtension = @"data";
 
+// Suffix appended to hang-report filenames so they can be distinguished from crash filenames on disk.
+static NSString *const kBugSplatHangFilenameSuffix = @"-hang";
+
+// Attribute keys attached to hang reports (and to crash reports sharing the same launch).
+static NSString *const kBugSplatHangAttrDurationMs = @"bugsplat-hang-duration-ms";
+static NSString *const kBugSplatHangAttrDetectedAt = @"bugsplat-hang-detected-at";
+static NSString *const kBugSplatHangAttrAppState = @"bugsplat-hang-app-state";
+static NSString *const kBugSplatHangAttrLaunchId = @"bugsplat-hang-launch-id";
+
 // Keys for crash metadata
 static NSString *const kBugSplatMetaKeyUserName = @"userName";
 static NSString *const kBugSplatMetaKeyUserEmail = @"userEmail";
@@ -50,7 +64,7 @@ static NSString *const kBugSplatMetaKeyApplicationVersion = @"applicationVersion
 static NSString *const kBugSplatMetaKeyAppKey = @"appKey";
 static NSString *const kBugSplatMetaKeyNotes = @"notes";
 
-@interface BugSplat ()
+@interface BugSplat () <BugSplatHangTrackerDelegate>
 
 @property (atomic, assign) BOOL isStartInvoked;
 @property (atomic, assign) BOOL sendingInProgress;
@@ -62,6 +76,11 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 @property (nonatomic, strong, nullable) BugSplatUploadService *uploadService;
 @property (nonatomic, copy, nullable) NSString *currentCrashFilename;
 @property (nonatomic, assign) BOOL isTestInstance;
+
+@property (nonatomic, strong, nullable) BugSplatHangTracker *hangTracker;
+@property (atomic, copy, nullable) NSString *currentHangFilename;
+@property (nonatomic, copy, nullable) NSString *launchId;
+@property (nonatomic, strong, nullable) dispatch_queue_t hangQueue;
 
 #if TARGET_OS_OSX
 @property (nonatomic, strong, nullable) BugSplatCrashReportWindow *crashReportWindow;
@@ -75,6 +94,14 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
     NSString *_applicationName;
     NSString *_applicationVersion;
     NSNumber *_debuggerAttachedOverride;
+
+    // Mach port of the main thread, captured on the main thread during -start (or test
+    // setup). Used to mark main as the crashed thread when generating a live hang report
+    // from the hang queue. MACH_PORT_NULL until captured.
+    //
+    // pthread_mach_thread_np does not add a port reference, so no cleanup is needed and
+    // the port remains valid for the lifetime of the main thread (i.e. the process).
+    mach_port_t _mainThreadMachPort;
 }
 
 + (instancetype)shared
@@ -114,6 +141,7 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
         self.sendingInProgress = NO;
         self.currentCrashFilename = nil;
         self.isTestInstance = NO;
+        self.hangDetectionThreshold = 2.0;
 
         // Configure PLCrashReporter
         // Note: Mach exception handling is not available on tvOS, use BSD signal handling instead
@@ -161,7 +189,8 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
         self.sendingInProgress = NO;
         self.currentCrashFilename = nil;
         self.isTestInstance = YES;
-        
+        self.hangDetectionThreshold = 2.0;
+
         _crashReporterInternal = crashReporter;
         _crashStorageInternal = crashStorage;
         _userDefaultsInternal = userDefaults;
@@ -247,7 +276,280 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
         return;
     }
 
+    [self startHangDetectionIfEnabled];
+
     self.isStartInvoked = YES;
+}
+
+#pragma mark - Hang Detection
+
+/// Returns YES when the current executable is an app extension (.appex bundle).
+- (BOOL)isRunningInAppExtension
+{
+    NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+    return [bundlePath hasSuffix:@".appex"];
+}
+
+- (void)startHangDetectionIfEnabled
+{
+    if (!self.enableHangDetection) {
+        return;
+    }
+    if (self.hangTracker) {
+        return;
+    }
+    if (self.isTestInstance) {
+        // Tests exercise the tracker directly; do not auto-start a real one.
+        return;
+    }
+    if ([self isRunningInAppExtension]) {
+        NSLog(@"BugSplat: Hang detection not supported in app extensions; skipping");
+        return;
+    }
+
+    // Capture the main thread's mach port while we are definitely on main, so the live
+    // hang report can mark main as the crashed thread (the report is generated later
+    // from the hang queue, where pthread_self would yield the wrong thread).
+    NSAssert([NSThread isMainThread], @"BugSplat -start must be invoked on the main thread for hang detection");
+    if (_mainThreadMachPort == MACH_PORT_NULL) {
+        _mainThreadMachPort = pthread_mach_thread_np(pthread_self());
+    }
+
+    // Generate a per-launch id and attach it as an attribute so crashes from this launch
+    // can be correlated with any fatal hang that was persisted before termination.
+    if (!self.launchId) {
+        self.launchId = [[NSUUID UUID] UUIDString];
+        [self setValue:self.launchId forAttribute:kBugSplatHangAttrLaunchId];
+    }
+
+    // Serialize hang delegate callbacks so detect / recover can't race on file I/O.
+    if (!self.hangQueue) {
+        self.hangQueue = dispatch_queue_create("com.bugsplat.hang-handler", DISPATCH_QUEUE_SERIAL);
+    }
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+    // Install the notification observers that maintain the cached application-active
+    // state the watchdog polls. Idempotent.
+    [BugSplat installApplicationActiveObservers];
+#endif
+
+    __weak __typeof(self) weakSelf = self;
+    NSTimeInterval threshold = self.hangDetectionThreshold;
+    self.hangTracker = [[BugSplatHangTracker alloc] initWithThresholdSeconds:threshold
+                                                                    delegate:self
+                                                      isDebuggerAttachedBlock:^BOOL {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        return strongSelf ? [strongSelf isDebuggerAttached] : NO;
+    }
+                                                            isAppActiveBlock:^BOOL {
+        return [BugSplat isApplicationActive];
+    }];
+
+    [self.hangTracker start];
+    NSLog(@"BugSplat: Hang detection enabled (threshold %.2fs)", self.hangTracker.thresholdSeconds);
+}
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+/// Cached foreground-active state, updated via NSNotificationCenter on the main thread
+/// and read without locking (or dispatching) from the hang-tracker watchdog thread.
+///
+/// Using dispatch_sync to the main queue here would deadlock: when the main thread is
+/// actually hung (exactly the case we want to report), the watchdog can never acquire
+/// main to read applicationState, so no hang report would ever be persisted.
+static _Atomic(bool) sBugSplatApplicationActive = true;
+
++ (void)installApplicationActiveObservers
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+
+        // Seed the cached state from the current application state.
+        atomic_store(&sBugSplatApplicationActive,
+                     [UIApplication sharedApplication].applicationState == UIApplicationStateActive);
+
+        [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                            object:nil
+                             queue:mainQueue
+                        usingBlock:^(NSNotification *note) {
+            atomic_store(&sBugSplatApplicationActive, true);
+        }];
+        [center addObserverForName:UIApplicationWillResignActiveNotification
+                            object:nil
+                             queue:mainQueue
+                        usingBlock:^(NSNotification *note) {
+            atomic_store(&sBugSplatApplicationActive, false);
+        }];
+        [center addObserverForName:UIApplicationDidEnterBackgroundNotification
+                            object:nil
+                             queue:mainQueue
+                        usingBlock:^(NSNotification *note) {
+            atomic_store(&sBugSplatApplicationActive, false);
+        }];
+        [center addObserverForName:UIApplicationWillEnterForegroundNotification
+                            object:nil
+                             queue:mainQueue
+                        usingBlock:^(NSNotification *note) {
+            // Foreground but not yet active - treat as inactive for hang purposes,
+            // DidBecomeActive will flip the flag shortly.
+            atomic_store(&sBugSplatApplicationActive, false);
+        }];
+    });
+}
+#endif
+
+/// Lock-free check for whether the app is currently active. Safe to call from any thread,
+/// including while the main thread is hung.
++ (BOOL)isApplicationActive
+{
+#if TARGET_OS_IOS || TARGET_OS_TV
+    return atomic_load(&sBugSplatApplicationActive);
+#else
+    return YES;
+#endif
+}
+
+#pragma mark - BugSplatHangTrackerDelegate
+
+- (void)hangTracker:(BugSplatHangTracker *)tracker
+didDetectHangWithDuration:(NSTimeInterval)duration
+           appState:(NSString *)appState
+{
+    // Callback runs on the tracker's watchdog thread; marshal to our serial queue.
+    dispatch_async(self.hangQueue, ^{
+        [self persistHangReportWithDuration:duration appState:appState];
+    });
+}
+
+- (void)hangTrackerDidRecoverFromHang:(BugSplatHangTracker *)tracker
+{
+    dispatch_async(self.hangQueue, ^{
+        NSString *filename = self.currentHangFilename;
+        self.currentHangFilename = nil;
+        if (filename) {
+            [self cleanupCrashReportWithFilename:filename];
+            NSLog(@"BugSplat: Main thread recovered from hang; removed persisted report %@", filename);
+        }
+    });
+}
+
+/**
+ * Capture a live report via PLCrashReporter with a synthetic "App Hang (Fatal)" exception,
+ * text-format it, and persist it (plus metadata) to the crashes directory so the normal
+ * next-launch scanner uploads it through the existing pipeline. Called on the hang queue.
+ */
+- (void)persistHangReportWithDuration:(NSTimeInterval)duration appState:(NSString *)appState
+{
+    NSString *reason = [NSString stringWithFormat:@"Main thread unresponsive for %.0f ms", duration * 1000.0];
+    NSException *hangException = [NSException exceptionWithName:@"App Hang (Fatal)"
+                                                         reason:reason
+                                                       userInfo:nil];
+
+    NSError *error = nil;
+    NSData *liveReportData = nil;
+    PLCrashReporter *plCrashReporter = (PLCrashReporter *)self.crashReporterInternal;
+    mach_port_t mainThreadPort = _mainThreadMachPort;
+    @try {
+        if (mainThreadPort != MACH_PORT_NULL) {
+            // Mark main as the crashed thread so the dashboard's crashed-thread view
+            // points at what's actually hung, rather than the hang-queue worker.
+            liveReportData = [plCrashReporter generateLiveReportWithThread:mainThreadPort
+                                                                 exception:hangException
+                                                                     error:&error];
+        } else {
+            liveReportData = [plCrashReporter generateLiveReportWithException:hangException error:&error];
+        }
+    } @catch (NSException *exception) {
+        NSLog(@"BugSplat: Exception generating live hang report: %@ - %@", exception.name, exception.reason);
+        return;
+    }
+
+    if (!liveReportData || liveReportData.length == 0) {
+        NSLog(@"BugSplat: Failed to generate live hang report: %@", error);
+        return;
+    }
+
+    NSString *reportText = nil;
+    @try {
+        PLCrashReport *parsed = [[PLCrashReport alloc] initWithData:liveReportData error:&error];
+        if (parsed) {
+            reportText = [PLCrashReportTextFormatter stringValueForCrashReport:parsed
+                                                                withTextFormat:PLCrashReportTextFormatiOS];
+        }
+    } @catch (NSException *exception) {
+        NSLog(@"BugSplat: Exception formatting live hang report: %@ - %@", exception.name, exception.reason);
+    }
+
+    if (reportText.length == 0) {
+        reportText = [NSString stringWithFormat:@"App Hang (Fatal)\n%@\n[Hang report text unavailable]\n", reason];
+    }
+
+    NSString *crashesDir = [self crashesDirectoryPath];
+    if (!crashesDir) {
+        NSLog(@"BugSplat: Failed to get crashes directory for hang report");
+        return;
+    }
+
+    NSString *hangFilename = [NSString stringWithFormat:@"%.0f%@",
+                              [NSDate timeIntervalSinceReferenceDate],
+                              kBugSplatHangFilenameSuffix];
+
+    NSData *textData = [reportText dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *crashFilePath = [[crashesDir stringByAppendingPathComponent:hangFilename]
+                               stringByAppendingPathExtension:kBugSplatCrashFileExtension];
+    if (![textData writeToFile:crashFilePath atomically:YES]) {
+        NSLog(@"BugSplat: Failed to write hang report to disk");
+        return;
+    }
+
+    // Build metadata. Unlike crashes there is no PLCrashReporter customData to extract from,
+    // so we snapshot current values directly - this is safe because the main thread is hung
+    // and nothing else is mutating these properties while this runs.
+    NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
+    NSISO8601DateFormatter *isoFormatter = [[NSISO8601DateFormatter alloc] init];
+    isoFormatter.formatOptions = NSISO8601DateFormatWithInternetDateTime;
+    NSDate *now = [NSDate date];
+    NSString *nowISO = [isoFormatter stringFromDate:now];
+
+    metadata[kBugSplatMetaKeyTimestamp] = nowISO;
+    metadata[kBugSplatMetaKeyDatabase] = self.bugSplatDatabase;
+    metadata[kBugSplatMetaKeyApplicationName] = self.resolvedApplicationName;
+    metadata[kBugSplatMetaKeyApplicationVersion] = self.resolvedApplicationVersion;
+    if (self.userName) metadata[kBugSplatMetaKeyUserName] = self.userName;
+    if (self.userEmail) metadata[kBugSplatMetaKeyUserEmail] = self.userEmail;
+    if (self.appKey) metadata[kBugSplatMetaKeyAppKey] = self.appKey;
+    if (self.notes) metadata[kBugSplatMetaKeyNotes] = self.notes;
+
+    NSMutableDictionary<NSString *, NSString *> *attributes = self.attributes
+        ? [self.attributes mutableCopy]
+        : [NSMutableDictionary dictionary];
+    attributes[kBugSplatHangAttrDurationMs] = [NSString stringWithFormat:@"%.0f", duration * 1000.0];
+    attributes[kBugSplatHangAttrDetectedAt] = nowISO;
+    attributes[kBugSplatHangAttrAppState] = appState ?: @"unknown";
+    if (self.launchId) {
+        attributes[kBugSplatHangAttrLaunchId] = self.launchId;
+    }
+    metadata[kBugSplatMetaKeyAttributes] = attributes;
+
+    // Mark auto-submittable so the next-launch scanner uploads silently without showing a dialog.
+    metadata[kBugSplatMetaKeyUserSubmitted] = @YES;
+
+    NSString *metaFilePath = [[crashesDir stringByAppendingPathComponent:hangFilename]
+                              stringByAppendingPathExtension:kBugSplatMetaFileExtension];
+    if (![metadata writeToFile:metaFilePath atomically:YES]) {
+        // Without the .meta file the next-launch scanner sees an orphan .crash that
+        // lacks userSubmitted=YES, database, and attributes - it would either fail to
+        // upload or surface a dialog instead of the intended silent submit. Drop the
+        // .crash too so we don't leak a half-formed report.
+        NSLog(@"BugSplat: Failed to write hang metadata; removing orphan crash file");
+        [[NSFileManager defaultManager] removeItemAtPath:crashFilePath error:nil];
+        return;
+    }
+
+    self.currentHangFilename = hangFilename;
+    NSLog(@"BugSplat: Persisted hang report %@ (duration %.0fms, state %@)",
+          hangFilename, duration * 1000.0, appState);
 }
 
 #pragma mark - Crash Report Handling
@@ -1556,6 +1858,26 @@ static NSString *const kBugSplatMetaKeyNotes = @"notes";
 - (void)setDebuggerAttachedOverride:(NSNumber *)value
 {
     _debuggerAttachedOverride = value;
+}
+
+- (void)setupHangInfrastructureForTesting
+{
+    if (!self.hangQueue) {
+        self.hangQueue = dispatch_queue_create("com.bugsplat.hang-handler.test", DISPATCH_QUEUE_SERIAL);
+    }
+    if (!self.launchId) {
+        self.launchId = [[NSUUID UUID] UUIDString];
+    }
+    // XCTest invokes setUp on the main thread, so capturing here yields the same port
+    // as the production path. Required by persistHangReportWithDuration:.
+    if (_mainThreadMachPort == MACH_PORT_NULL) {
+        _mainThreadMachPort = pthread_mach_thread_np(pthread_self());
+    }
+}
+
+- (dispatch_queue_t)hangQueueForTesting
+{
+    return self.hangQueue;
 }
 
 @end

--- a/BugSplat.xcodeproj/project.pbxproj
+++ b/BugSplat.xcodeproj/project.pbxproj
@@ -7,41 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		CC0000022E3FC00000000002 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
-		CC0000032E3FC00000000003 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
-		CC0000042E3FC00000000004 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
-/* Test target build files - macOS */
-		TT0000012E3FE00000000001 /* BugSplatUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */; };
-		TT0000022E3FE00000000002 /* BugSplatZipHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */; };
-		TT0000032E3FE00000000003 /* BugSplatAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */; };
-		TT0000042E3FE00000000004 /* BugSplatUploadServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */; };
-		TT0000052E3FE00000000005 /* BugSplatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000142E3FE00000000014 /* BugSplatTests.m */; };
-		TT0000062E3FE00000000006 /* MockURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000152E3FE00000000015 /* MockURLSession.m */; };
-		TT0000072E3FE00000000007 /* MockCrashStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000162E3FE00000000016 /* MockCrashStorage.m */; };
-		TT0000082E3FE00000000008 /* MockCrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000172E3FE00000000017 /* MockCrashReporter.m */; };
-		TT0000092E3FE00000000009 /* MockBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000182E3FE00000000018 /* MockBundle.m */; };
-		TT00000A2E3FE0000000000A /* MockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000192E3FE00000000019 /* MockUserDefaults.m */; };
-		TT00000B2E3FE0000000000B /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
-		TT00000C2E3FE0000000000C /* BugSplatUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 637DF0472D49A50800DDD8FE /* BugSplatUtilities.m */; };
-		TT00000D2E3FE0000000000D /* BugSplatZipHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000142E3FA00000000014 /* BugSplatZipHelper.m */; };
-		TT00000E2E3FE0000000000E /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
-		TT00000F2E3FE0000000000F /* BugSplatUploadService.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000042E3FA00000000004 /* BugSplatUploadService.m */; };
-		TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */; };
-		TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
-/* Test target build files - iOS */
-		TT0000702E3FE00000000070 /* BugSplatUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */; };
-		TT0000712E3FE00000000071 /* BugSplatZipHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */; };
-		TT0000722E3FE00000000072 /* BugSplatAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */; };
-		TT0000732E3FE00000000073 /* BugSplatUploadServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */; };
-		TT0000742E3FE00000000074 /* BugSplatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000142E3FE00000000014 /* BugSplatTests.m */; };
-		TT0000752E3FE00000000075 /* MockURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000152E3FE00000000015 /* MockURLSession.m */; };
-		TT0000762E3FE00000000076 /* MockCrashStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000162E3FE00000000016 /* MockCrashStorage.m */; };
-		TT0000772E3FE00000000077 /* MockCrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000172E3FE00000000017 /* MockCrashReporter.m */; };
-		TT0000782E3FE00000000078 /* MockBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000182E3FE00000000018 /* MockBundle.m */; };
-		TT0000792E3FE0000000007A /* MockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000192E3FE00000000019 /* MockUserDefaults.m */; };
-		TT00007A2E3FE0000000007A /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1FC2B9283B000AED3E3 /* BugSplat.framework */; };
-		TT00007B2E3FE0000000007B /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
-		DD0000012E3FD00000000001 /* bugsplat-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = DD0000002E3FD00000000000 /* bugsplat-logo.png */; };
+		0A3C2DA5364740BBC400AEE9 /* BugSplatHangTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */; };
+		10992FD3161BE77C2DEA24AA /* BugSplatHangTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */; };
+		5A26D84ECCF0BD4416CA3608 /* BugSplatHangTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 12CF7E5C55F7AC9E05B83527 /* BugSplatHangTracker.h */; };
+		5DF567F3A771ECB5E74796EF /* BugSplatHangTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D0C5FD3AB29CB3196AA013 /* BugSplatHangTrackerTests.m */; };
 		63598C432BA0CCD500770E43 /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
 		63598C442BA0CCD500770E43 /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
 		637DF0452D49A49C00DDD8FE /* BugSplatUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */; };
@@ -59,6 +28,8 @@
 		63E233842B9711AB0066C7FC /* BugSplatAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 63E2337C2B9710420066C7FC /* BugSplatAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63E233852B9711B10066C7FC /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
 		63E233862B9715B50066C7FC /* BugSplat.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C6E1FE2B9283B000AED3E3 /* BugSplat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73DEAA0D4412D3A9CF562633 /* BugSplatHangPersistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */; };
+		7C235FBB8C978B3EC7E2CE49 /* BugSplatHangPersistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */; };
 		AA0000032E3FA00000000003 /* BugSplatUploadService.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000042E3FA00000000004 /* BugSplatUploadService.m */; };
 		AA0000052E3FA00000000005 /* BugSplatUploadService.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000042E3FA00000000004 /* BugSplatUploadService.m */; };
 		AA0000062E3FA00000000006 /* BugSplatUploadService.h in Headers */ = {isa = PBXBuildFile; fileRef = AA0000072E3FA00000000007 /* BugSplatUploadService.h */; };
@@ -69,6 +40,8 @@
 		AA0000152E3FA00000000015 /* BugSplatZipHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000142E3FA00000000014 /* BugSplatZipHelper.m */; };
 		AA0000162E3FA00000000016 /* BugSplatZipHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA0000172E3FA00000000017 /* BugSplatZipHelper.h */; };
 		AA0000182E3FA00000000018 /* BugSplatZipHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA0000172E3FA00000000017 /* BugSplatZipHelper.h */; };
+		AF1188A1AEE700C402DDFBC8 /* BugSplatHangTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03D0C5FD3AB29CB3196AA013 /* BugSplatHangTrackerTests.m */; };
+		B4239B8F7096BCBF173425EB /* BugSplatHangTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 12CF7E5C55F7AC9E05B83527 /* BugSplatHangTracker.h */; };
 		BB0000012E3FB00000000001 /* BugSplat.m in Sources */ = {isa = PBXBuildFile; fileRef = 63598C422BA0CCD500770E43 /* BugSplat.m */; };
 		BB0000022E3FB00000000002 /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
 		BB0000032E3FB00000000003 /* BugSplatUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 637DF0472D49A50800DDD8FE /* BugSplatUtilities.m */; };
@@ -81,32 +54,58 @@
 		BB0000102E3FB00000000010 /* BugSplatUploadService.h in Headers */ = {isa = PBXBuildFile; fileRef = AA0000072E3FA00000000007 /* BugSplatUploadService.h */; };
 		BB0000112E3FB00000000011 /* BugSplatZipHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA0000172E3FA00000000017 /* BugSplatZipHelper.h */; };
 		BB0000122E3FB00000000012 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 63905E952D83912E009CDBEE /* PrivacyInfo.xcprivacy */; };
+		CC0000022E3FC00000000002 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
+		CC0000032E3FC00000000003 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
+		CC0000042E3FC00000000004 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
+		D9056899F46474A220BBB808 /* BugSplatHangTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 12CF7E5C55F7AC9E05B83527 /* BugSplatHangTracker.h */; };
+		DD0000012E3FD00000000001 /* bugsplat-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = DD0000002E3FD00000000000 /* bugsplat-logo.png */; };
+		EE0D97D44D20AC01A69E9925 /* BugSplatHangTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */; };
+		TT0000012E3FE00000000001 /* BugSplatUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */; };
+		TT0000022E3FE00000000002 /* BugSplatZipHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */; };
+		TT0000032E3FE00000000003 /* BugSplatAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */; };
+		TT0000042E3FE00000000004 /* BugSplatUploadServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */; };
+		TT0000052E3FE00000000005 /* BugSplatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000142E3FE00000000014 /* BugSplatTests.m */; };
+		TT0000062E3FE00000000006 /* MockURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000152E3FE00000000015 /* MockURLSession.m */; };
+		TT0000072E3FE00000000007 /* MockCrashStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000162E3FE00000000016 /* MockCrashStorage.m */; };
+		TT0000082E3FE00000000008 /* MockCrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000172E3FE00000000017 /* MockCrashReporter.m */; };
+		TT0000092E3FE00000000009 /* MockBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000182E3FE00000000018 /* MockBundle.m */; };
+		TT00000A2E3FE0000000000A /* MockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000192E3FE00000000019 /* MockUserDefaults.m */; };
+		TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1ED2B92831A00AED3E3 /* BugSplat.framework */; };
+		TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
+		TT0000702E3FE00000000070 /* BugSplatUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */; };
+		TT0000712E3FE00000000071 /* BugSplatZipHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */; };
+		TT0000722E3FE00000000072 /* BugSplatAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */; };
+		TT0000732E3FE00000000073 /* BugSplatUploadServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */; };
+		TT0000742E3FE00000000074 /* BugSplatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000142E3FE00000000014 /* BugSplatTests.m */; };
+		TT0000752E3FE00000000075 /* MockURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000152E3FE00000000015 /* MockURLSession.m */; };
+		TT0000762E3FE00000000076 /* MockCrashStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000162E3FE00000000016 /* MockCrashStorage.m */; };
+		TT0000772E3FE00000000077 /* MockCrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000172E3FE00000000017 /* MockCrashReporter.m */; };
+		TT0000782E3FE00000000078 /* MockBundle.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000182E3FE00000000018 /* MockBundle.m */; };
+		TT0000792E3FE0000000007A /* MockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = TT0000192E3FE00000000019 /* MockUserDefaults.m */; };
+		TT00007A2E3FE0000000007A /* BugSplat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6E1FC2B9283B000AED3E3 /* BugSplat.framework */; };
+		TT00007B2E3FE0000000007B /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC0000012E3FC00000000001 /* CrashReporter.xcframework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		TT0000402E3FE00000000040 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 63C6E1E42B92831A00AED3E3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 63C6E1EC2B92831A00AED3E3;
+			remoteInfo = BugSplatMac;
+		};
+		TT0000812E3FE00000000081 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 63C6E1E42B92831A00AED3E3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 63C6E1FB2B9283B000AED3E3;
+			remoteInfo = BugSplat;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
-		CC0000012E3FC00000000001 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "Vendor/PLCrashReporter/CrashReporter.xcframework"; sourceTree = SOURCE_ROOT; };
-		DD0000002E3FD00000000000 /* bugsplat-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Resources/bugsplat-logo.png"; sourceTree = SOURCE_ROOT; };
-/* Test file references */
-		TT0000002E3FE00000000000 /* BugSplatMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugSplatMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		TT0000802E3FE00000000080 /* BugSplatIOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugSplatIOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUtilitiesTests.m; sourceTree = "<group>"; };
-		TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatZipHelperTests.m; sourceTree = "<group>"; };
-		TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatAttachmentTests.m; sourceTree = "<group>"; };
-		TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUploadServiceTests.m; sourceTree = "<group>"; };
-		TT0000142E3FE00000000014 /* BugSplatTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatTests.m; sourceTree = "<group>"; };
-		TT0000152E3FE00000000015 /* MockURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockURLSession.m; sourceTree = "<group>"; };
-		TT0000252E3FE00000000025 /* MockURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockURLSession.h; sourceTree = "<group>"; };
-		TT0000162E3FE00000000016 /* MockCrashStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCrashStorage.m; sourceTree = "<group>"; };
-		TT0000262E3FE00000000026 /* MockCrashStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCrashStorage.h; sourceTree = "<group>"; };
-		TT0000172E3FE00000000017 /* MockCrashReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCrashReporter.m; sourceTree = "<group>"; };
-		TT0000272E3FE00000000027 /* MockCrashReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCrashReporter.h; sourceTree = "<group>"; };
-		TT0000182E3FE00000000018 /* MockBundle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockBundle.m; sourceTree = "<group>"; };
-		TT0000282E3FE00000000028 /* MockBundle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockBundle.h; sourceTree = "<group>"; };
-		TT0000192E3FE00000000019 /* MockUserDefaults.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUserDefaults.m; sourceTree = "<group>"; };
-		TT0000292E3FE00000000029 /* MockUserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUserDefaults.h; sourceTree = "<group>"; };
-		TT00001A2E3FE0000000001A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		TT00001B2E3FE0000000001B /* BugSplatTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatTestSupport.h; sourceTree = "<group>"; };
-		TT00001C2E3FE0000000001C /* BugSplat+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugSplat+Testing.h"; sourceTree = "<group>"; };
+		03D0C5FD3AB29CB3196AA013 /* BugSplatHangTrackerTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BugSplatHangTrackerTests.m; sourceTree = "<group>"; };
+		12CF7E5C55F7AC9E05B83527 /* BugSplatHangTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = BugSplatHangTracker.h; sourceTree = "<group>"; };
 		6344718C2B9695C500EBEBEB /* BugSplatDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugSplatDelegate.h; sourceTree = "<group>"; };
 		63598C422BA0CCD500770E43 /* BugSplat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugSplat.m; sourceTree = "<group>"; };
 		637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatUtilities.h; sourceTree = "<group>"; };
@@ -118,6 +117,8 @@
 		63D006F92BBF785B00587FBF /* BugSplatMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatMac.h; sourceTree = "<group>"; };
 		63E2337A2B9710410066C7FC /* BugSplatAttachment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugSplatAttachment.m; sourceTree = "<group>"; };
 		63E2337C2B9710420066C7FC /* BugSplatAttachment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugSplatAttachment.h; sourceTree = "<group>"; };
+		680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BugSplatHangPersistenceTests.m; sourceTree = "<group>"; };
+		6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BugSplatHangTracker.m; sourceTree = "<group>"; };
 		AA0000042E3FA00000000004 /* BugSplatUploadService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUploadService.m; sourceTree = "<group>"; };
 		AA0000072E3FA00000000007 /* BugSplatUploadService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatUploadService.h; sourceTree = "<group>"; };
 		AA000010E3FA0000000000010 /* BugSplatCrashReportWindow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatCrashReportWindow.m; sourceTree = "<group>"; };
@@ -125,6 +126,28 @@
 		AA0000142E3FA00000000014 /* BugSplatZipHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatZipHelper.m; sourceTree = "<group>"; };
 		AA0000172E3FA00000000017 /* BugSplatZipHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatZipHelper.h; sourceTree = "<group>"; };
 		BB0000002E3FB00000000000 /* BugSplat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugSplat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC0000012E3FC00000000001 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Vendor/PLCrashReporter/CrashReporter.xcframework; sourceTree = SOURCE_ROOT; };
+		DD0000002E3FD00000000000 /* bugsplat-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Resources/bugsplat-logo.png"; sourceTree = SOURCE_ROOT; };
+		TT0000002E3FE00000000000 /* BugSplatMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugSplatMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		TT0000102E3FE00000000010 /* BugSplatUtilitiesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUtilitiesTests.m; sourceTree = "<group>"; };
+		TT0000112E3FE00000000011 /* BugSplatZipHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatZipHelperTests.m; sourceTree = "<group>"; };
+		TT0000122E3FE00000000012 /* BugSplatAttachmentTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatAttachmentTests.m; sourceTree = "<group>"; };
+		TT0000132E3FE00000000013 /* BugSplatUploadServiceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUploadServiceTests.m; sourceTree = "<group>"; };
+		TT0000142E3FE00000000014 /* BugSplatTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatTests.m; sourceTree = "<group>"; };
+		TT0000152E3FE00000000015 /* MockURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockURLSession.m; sourceTree = "<group>"; };
+		TT0000162E3FE00000000016 /* MockCrashStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCrashStorage.m; sourceTree = "<group>"; };
+		TT0000172E3FE00000000017 /* MockCrashReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockCrashReporter.m; sourceTree = "<group>"; };
+		TT0000182E3FE00000000018 /* MockBundle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockBundle.m; sourceTree = "<group>"; };
+		TT0000192E3FE00000000019 /* MockUserDefaults.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUserDefaults.m; sourceTree = "<group>"; };
+		TT00001A2E3FE0000000001A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		TT00001B2E3FE0000000001B /* BugSplatTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatTestSupport.h; sourceTree = "<group>"; };
+		TT00001C2E3FE0000000001C /* BugSplat+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugSplat+Testing.h"; sourceTree = "<group>"; };
+		TT0000252E3FE00000000025 /* MockURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockURLSession.h; sourceTree = "<group>"; };
+		TT0000262E3FE00000000026 /* MockCrashStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCrashStorage.h; sourceTree = "<group>"; };
+		TT0000272E3FE00000000027 /* MockCrashReporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCrashReporter.h; sourceTree = "<group>"; };
+		TT0000282E3FE00000000028 /* MockBundle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockBundle.h; sourceTree = "<group>"; };
+		TT0000292E3FE00000000029 /* MockUserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUserDefaults.h; sourceTree = "<group>"; };
+		TT0000802E3FE00000000080 /* BugSplatIOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugSplatIOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +172,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC0000042E3FC00000000004 /* CrashReporter.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TT0000522E3FE00000000052 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */,
+				TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TT0000852E3FE00000000085 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				TT00007A2E3FE0000000007A /* BugSplat.framework in Frameworks */,
+				TT00007B2E3FE0000000007B /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -179,6 +220,8 @@
 				TT0000302E3FE00000000030 /* Tests */,
 				63C6E1EE2B92831A00AED3E3 /* Products */,
 				63C6E2062B9285F400AED3E3 /* Frameworks */,
+				12CF7E5C55F7AC9E05B83527 /* BugSplatHangTracker.h */,
+				6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */,
 			);
 			sourceTree = "<group>";
 		};
@@ -192,6 +235,14 @@
 				TT0000802E3FE00000000080 /* BugSplatIOSTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		63C6E2062B9285F400AED3E3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CC0000012E3FC00000000001 /* CrashReporter.xcframework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		TT0000302E3FE00000000030 /* Tests */ = {
@@ -221,51 +272,29 @@
 				TT0000292E3FE00000000029 /* MockUserDefaults.h */,
 				TT0000192E3FE00000000019 /* MockUserDefaults.m */,
 				TT00001A2E3FE0000000001A /* Info.plist */,
+				03D0C5FD3AB29CB3196AA013 /* BugSplatHangTrackerTests.m */,
+				680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */,
 			);
 			path = BugSplatTests;
 			sourceTree = "<group>";
 		};
-		63C6E2062B9285F400AED3E3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				CC0000012E3FC00000000001 /* CrashReporter.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
-/* Begin PBXContainerItemProxy section */
-		TT0000402E3FE00000000040 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 63C6E1E42B92831A00AED3E3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 63C6E1EC2B92831A00AED3E3;
-			remoteInfo = BugSplatMac;
-		};
-		TT0000812E3FE00000000081 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 63C6E1E42B92831A00AED3E3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 63C6E1FB2B9283B000AED3E3;
-			remoteInfo = BugSplat;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXTargetDependency section */
-		TT0000412E3FE00000000041 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 63C6E1EC2B92831A00AED3E3 /* BugSplatMac */;
-			targetProxy = TT0000402E3FE00000000040 /* PBXContainerItemProxy */;
-		};
-		TT0000822E3FE00000000082 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 63C6E1FB2B9283B000AED3E3 /* BugSplat */;
-			targetProxy = TT0000812E3FE00000000081 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin PBXHeadersBuildPhase section */
+		3F362E6693037A725EFD4090 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6207040AF087699FE03E82BB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		63C6E1E82B92831A00AED3E3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -278,6 +307,7 @@
 				AA0000062E3FA00000000006 /* BugSplatUploadService.h in Headers */,
 				AA0000112E3FA00000000011 /* BugSplatCrashReportWindow.h in Headers */,
 				AA0000162E3FA00000000016 /* BugSplatZipHelper.h in Headers */,
+				D9056899F46474A220BBB808 /* BugSplatHangTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +321,7 @@
 				637DF0462D49A49C00DDD8FE /* BugSplatUtilities.h in Headers */,
 				AA0000082E3FA00000000008 /* BugSplatUploadService.h in Headers */,
 				AA0000182E3FA00000000018 /* BugSplatZipHelper.h in Headers */,
+				5A26D84ECCF0BD4416CA3608 /* BugSplatHangTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -304,6 +335,7 @@
 				BB0000092E3FB00000000009 /* BugSplatUtilities.h in Headers */,
 				BB0000102E3FB00000000010 /* BugSplatUploadService.h in Headers */,
 				BB0000112E3FB00000000011 /* BugSplatZipHelper.h in Headers */,
+				B4239B8F7096BCBF173425EB /* BugSplatHangTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,6 +403,7 @@
 				TT0000512E3FE00000000051 /* Sources */,
 				TT0000522E3FE00000000052 /* Frameworks */,
 				TT0000532E3FE00000000053 /* Resources */,
+				6207040AF087699FE03E82BB /* Headers */,
 			);
 			buildRules = (
 			);
@@ -389,6 +422,7 @@
 				TT0000842E3FE00000000084 /* Sources */,
 				TT0000852E3FE00000000085 /* Frameworks */,
 				TT0000862E3FE00000000086 /* Resources */,
+				3F362E6693037A725EFD4090 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -468,6 +502,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		TT0000532E3FE00000000053 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		TT0000862E3FE00000000086 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -481,6 +529,7 @@
 				AA0000032E3FA00000000003 /* BugSplatUploadService.m in Sources */,
 				AA0000092E3FA00000000009 /* BugSplatCrashReportWindow.m in Sources */,
 				AA0000132E3FA00000000013 /* BugSplatZipHelper.m in Sources */,
+				10992FD3161BE77C2DEA24AA /* BugSplatHangTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,6 +542,7 @@
 				63598C442BA0CCD500770E43 /* BugSplat.m in Sources */,
 				AA0000052E3FA00000000005 /* BugSplatUploadService.m in Sources */,
 				AA0000152E3FA00000000015 /* BugSplatZipHelper.m in Sources */,
+				EE0D97D44D20AC01A69E9925 /* BugSplatHangTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,6 +555,7 @@
 				BB0000032E3FB00000000003 /* BugSplatUtilities.m in Sources */,
 				BB0000042E3FB00000000004 /* BugSplatUploadService.m in Sources */,
 				BB0000052E3FB00000000005 /* BugSplatZipHelper.m in Sources */,
+				0A3C2DA5364740BBC400AEE9 /* BugSplatHangTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -522,22 +573,8 @@
 				TT0000082E3FE00000000008 /* MockCrashReporter.m in Sources */,
 				TT0000092E3FE00000000009 /* MockBundle.m in Sources */,
 				TT00000A2E3FE0000000000A /* MockUserDefaults.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		TT0000522E3FE00000000052 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				TT0000202E3FE00000000020 /* BugSplat.framework in Frameworks */,
-				TT0000212E3FE00000000021 /* CrashReporter.xcframework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		TT0000532E3FE00000000053 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				5DF567F3A771ECB5E74796EF /* BugSplatHangTrackerTests.m in Sources */,
+				7C235FBB8C978B3EC7E2CE49 /* BugSplatHangPersistenceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -555,26 +592,25 @@
 				TT0000772E3FE00000000077 /* MockCrashReporter.m in Sources */,
 				TT0000782E3FE00000000078 /* MockBundle.m in Sources */,
 				TT0000792E3FE0000000007A /* MockUserDefaults.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		TT0000852E3FE00000000085 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				TT00007A2E3FE0000000007A /* BugSplat.framework in Frameworks */,
-				TT00007B2E3FE0000000007B /* CrashReporter.xcframework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		TT0000862E3FE00000000086 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				AF1188A1AEE700C402DDFBC8 /* BugSplatHangTrackerTests.m in Sources */,
+				73DEAA0D4412D3A9CF562633 /* BugSplatHangPersistenceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		TT0000412E3FE00000000041 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 63C6E1EC2B92831A00AED3E3 /* BugSplatMac */;
+			targetProxy = TT0000402E3FE00000000040 /* PBXContainerItemProxy */;
+		};
+		TT0000822E3FE00000000082 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 63C6E1FB2B9283B000AED3E3 /* BugSplat */;
+			targetProxy = TT0000812E3FE00000000081 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		63C6E1F22B92831A00AED3E3 /* Debug */ = {

--- a/BugSplatHangTracker.h
+++ b/BugSplatHangTracker.h
@@ -1,0 +1,101 @@
+//
+//  BugSplatHangTracker.h
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class BugSplatHangTracker;
+
+/**
+ * Delegate protocol for BugSplatHangTracker.
+ *
+ * `hangTracker:didDetectHangWithDuration:appState:` is invoked on the tracker's private
+ * watchdog thread. `hangTrackerDidRecoverFromHang:` is invoked on a GCD global utility
+ * queue (dispatched off the main thread so disk I/O can't block recovery). Neither
+ * callback runs on the main thread; implementers must not perform UI work directly and
+ * should dispatch to a queue if needed.
+ */
+@protocol BugSplatHangTrackerDelegate <NSObject>
+
+/**
+ * Called when the main thread has been unresponsive for at least the configured threshold.
+ *
+ * @param tracker    The tracker that detected the hang.
+ * @param duration   Approximate elapsed time the main thread has been unresponsive, in seconds.
+ * @param appState   Short string describing the app state at detection time
+ *                   ("active", "background", or "unknown").
+ */
+- (void)hangTracker:(BugSplatHangTracker *)tracker
+didDetectHangWithDuration:(NSTimeInterval)duration
+            appState:(NSString *)appState;
+
+/**
+ * Called after a hang was detected and the main thread has since resumed.
+ * Exists so the integrator can remove a persisted hang report - the main thread recovered
+ * and the hang is no longer fatal.
+ */
+- (void)hangTrackerDidRecoverFromHang:(BugSplatHangTracker *)tracker;
+
+@end
+
+
+/**
+ * Monitors the main thread for hangs.
+ *
+ * A dedicated low-QoS watchdog thread polls every `threshold / 5` seconds (clamped to
+ * at least 100ms). Each poll dispatches a small "ping" block to the main queue and
+ * increments an atomic counter; the ping block, when serviced, resets that counter.
+ * If the counter accumulates enough unanswered pings to cover `thresholdSeconds`, the
+ * main thread is considered hung and the delegate is notified. When the main thread
+ * later services a ping, a recovery callback fires so the integrator can discard a
+ * previously persisted hang report.
+ *
+ * Callers are expected to invoke `-start` from the main thread.
+ */
+@interface BugSplatHangTracker : NSObject
+
+/**
+ * Initialize a tracker with the given threshold and delegate.
+ *
+ * @param thresholdSeconds       Main-thread processing duration that triggers a hang.
+ *                               Values below 0.1s are clamped to 0.1s.
+ * @param delegate               Receives hang / recovery callbacks on the watchdog thread.
+ * @param isDebuggerAttachedBlock Optional predicate checked each poll. When it returns YES
+ *                               the tracker suppresses detection for that poll. Pass nil
+ *                               to disable the guard (useful for tests).
+ * @param isAppActiveBlock       Optional predicate checked each poll. When it returns NO
+ *                               the tracker suppresses detection for that poll. Pass nil
+ *                               to disable the guard (useful for tests or for macOS where
+ *                               UIApplication is unavailable).
+ */
+- (instancetype)initWithThresholdSeconds:(NSTimeInterval)thresholdSeconds
+                                 delegate:(id<BugSplatHangTrackerDelegate>)delegate
+                   isDebuggerAttachedBlock:(nullable BOOL(^)(void))isDebuggerAttachedBlock
+                         isAppActiveBlock:(nullable BOOL(^)(void))isAppActiveBlock;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Start monitoring. Spawns the watchdog thread, which will begin pinging the main
+ * queue on its poll interval. Must be called from the main thread.
+ */
+- (void)start;
+
+/**
+ * Stop monitoring. Signals the watchdog thread to exit. Safe to call multiple times.
+ */
+- (void)stop;
+
+/// YES when the watchdog thread is running.
+@property (atomic, readonly, getter=isRunning) BOOL running;
+
+/// Configured threshold in seconds (clamped to >= 0.1).
+@property (nonatomic, readonly) NSTimeInterval thresholdSeconds;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugSplatHangTracker.m
+++ b/BugSplatHangTracker.m
@@ -1,0 +1,271 @@
+//
+//  BugSplatHangTracker.m
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import "BugSplatHangTracker.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <stdatomic.h>
+#import <pthread.h>
+#import <mach/mach.h>
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+#import <UIKit/UIKit.h>
+#endif
+
+static const NSTimeInterval kMinThresholdSeconds = 0.1;
+static const NSTimeInterval kMinPollIntervalSeconds = 0.1;
+
+/// Poll interval is threshold / 5, clamped to a reasonable floor.
+static inline NSTimeInterval BugSplatHangPollInterval(NSTimeInterval threshold) {
+    NSTimeInterval interval = threshold / 5.0;
+    return interval < kMinPollIntervalSeconds ? kMinPollIntervalSeconds : interval;
+}
+
+/// Maximum number of consecutive unanswered pings before declaring a hang.
+/// `ceil(threshold / pollInterval)` ensures the elapsed time covered by the
+/// unanswered pings is at least `threshold`.
+static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold) {
+    NSTimeInterval pollInterval = BugSplatHangPollInterval(threshold);
+    NSInteger n = (NSInteger)ceil(threshold / pollInterval);
+    return n < 1 ? 1 : n;
+}
+
+
+@interface BugSplatHangTracker ()
+@property (atomic, readwrite, getter=isRunning) BOOL running;
+@property (nonatomic, weak) id<BugSplatHangTrackerDelegate> delegate;
+@property (nonatomic, copy, nullable) BOOL(^isDebuggerAttachedBlock)(void);
+@property (nonatomic, copy, nullable) BOOL(^isAppActiveBlock)(void);
+@property (nonatomic, copy) CFAbsoluteTime(^clockBlock)(void);
+@property (nonatomic, copy) void(^recoveryDispatcher)(dispatch_block_t);
+@property (nonatomic, copy) void(^pingDispatcher)(dispatch_block_t);
+@property (nonatomic, strong, nullable) NSThread *watchdogThread;
+@end
+
+
+@implementation BugSplatHangTracker {
+    // Number of consecutive watchdog polls during which the main thread has
+    // not serviced a dispatched ping. Each poll dispatches a ping block to the
+    // main queue; the ping block resets this counter to 0. If the counter
+    // reaches the threshold-derived limit, the main thread has been blocked
+    // for at least `thresholdSeconds`.
+    _Atomic(int32_t) _unansweredPings;
+
+    // Set to YES once a hang has been reported for the current window;
+    // cleared by the next pong (which also triggers a recovery callback).
+    _Atomic(bool) _hangReportedForCurrentWindow;
+}
+
+- (instancetype)initWithThresholdSeconds:(NSTimeInterval)thresholdSeconds
+                                 delegate:(id<BugSplatHangTrackerDelegate>)delegate
+                   isDebuggerAttachedBlock:(BOOL(^)(void))isDebuggerAttachedBlock
+                         isAppActiveBlock:(BOOL(^)(void))isAppActiveBlock {
+    return [self initWithThresholdSeconds:thresholdSeconds
+                                 delegate:delegate
+                   isDebuggerAttachedBlock:isDebuggerAttachedBlock
+                          isAppActiveBlock:isAppActiveBlock
+                                clockBlock:nil
+                        recoveryDispatcher:nil
+                             pingDispatcher:nil];
+}
+
+- (instancetype)initWithThresholdSeconds:(NSTimeInterval)thresholdSeconds
+                                 delegate:(id<BugSplatHangTrackerDelegate>)delegate
+                   isDebuggerAttachedBlock:(BOOL(^)(void))isDebuggerAttachedBlock
+                         isAppActiveBlock:(BOOL(^)(void))isAppActiveBlock
+                                clockBlock:(CFAbsoluteTime(^)(void))clockBlock
+                       recoveryDispatcher:(void(^)(dispatch_block_t))recoveryDispatcher
+                            pingDispatcher:(void(^)(dispatch_block_t))pingDispatcher {
+    if (self = [super init]) {
+        _thresholdSeconds = thresholdSeconds < kMinThresholdSeconds ? kMinThresholdSeconds : thresholdSeconds;
+        _delegate = delegate;
+        _isDebuggerAttachedBlock = [isDebuggerAttachedBlock copy];
+        _isAppActiveBlock = [isAppActiveBlock copy];
+        if (clockBlock) {
+            _clockBlock = [clockBlock copy];
+        } else {
+            _clockBlock = ^CFAbsoluteTime{ return CFAbsoluteTimeGetCurrent(); };
+        }
+        if (recoveryDispatcher) {
+            _recoveryDispatcher = [recoveryDispatcher copy];
+        } else {
+            _recoveryDispatcher = ^(dispatch_block_t b) {
+                dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), b);
+            };
+        }
+        if (pingDispatcher) {
+            _pingDispatcher = [pingDispatcher copy];
+        } else {
+            _pingDispatcher = ^(dispatch_block_t b) {
+                dispatch_async(dispatch_get_main_queue(), b);
+            };
+        }
+        atomic_init(&_unansweredPings, 0);
+        atomic_init(&_hangReportedForCurrentWindow, false);
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [self stop];
+}
+
+#pragma mark - Public API
+
+- (void)start {
+    NSAssert([NSThread isMainThread], @"BugSplatHangTracker -start must be called on the main thread");
+    if (self.isRunning) {
+        return;
+    }
+    self.running = YES;
+    atomic_store(&_unansweredPings, 0);
+    atomic_store(&_hangReportedForCurrentWindow, false);
+
+    NSThread *thread = [[NSThread alloc] initWithTarget:self
+                                               selector:@selector(watchdogThreadMain)
+                                                 object:nil];
+    thread.name = @"com.bugsplat.hang-tracker";
+    thread.qualityOfService = NSQualityOfServiceUtility;
+    self.watchdogThread = thread;
+    [thread start];
+}
+
+- (void)stop {
+    if (!self.isRunning) {
+        return;
+    }
+    // Flipping running=NO causes the watchdog loop to exit on its next
+    // iteration. The thread retains self until it returns, so no in-flight
+    // ping callback can call into a deallocated tracker.
+    self.running = NO;
+    self.watchdogThread = nil;
+}
+
+#pragma mark - Watchdog Thread
+
+- (void)watchdogThreadMain {
+    NSTimeInterval pollInterval = BugSplatHangPollInterval(self.thresholdSeconds);
+
+    __weak __typeof(self) weakSelf = self;
+    dispatch_block_t ping = ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf handleMainQueuePong];
+    };
+
+    while (self.isRunning) {
+        @autoreleasepool {
+            // Send a ping to the main queue. If the main thread is healthy it
+            // will service this block before the next poll; if it is hung the
+            // block will sit on the main queue and our counter will tick up.
+            self.pingDispatcher(ping);
+
+            CFAbsoluteTime sleepStart = self.clockBlock();
+            [NSThread sleepForTimeInterval:pollInterval];
+
+            if (!self.isRunning) {
+                break;
+            }
+
+            CFAbsoluteTime sleepEnd = self.clockBlock();
+            [self _processPollWithActualSleepDuration:(sleepEnd - sleepStart)];
+        }
+    }
+}
+
+/// Per-poll watchdog logic, factored out of the thread loop so tests can drive
+/// it deterministically without spawning a real thread.
+- (void)_processPollWithActualSleepDuration:(NSTimeInterval)actualSleep {
+    NSTimeInterval threshold = self.thresholdSeconds;
+    NSInteger maxUnansweredPings = BugSplatHangMaxUnansweredPings(threshold);
+
+    // Suspension guard: if our sleep took noticeably longer than the threshold,
+    // the device was suspended or the process was put to sleep. Reset state -
+    // we don't want the unanswered backlog to fire a "hang" the moment we wake.
+    if (actualSleep > threshold * 2.0) {
+        atomic_store(&_unansweredPings, 0);
+        return;
+    }
+
+    // Debugger guard.
+    BOOL(^debuggerCheck)(void) = self.isDebuggerAttachedBlock;
+    if (debuggerCheck && debuggerCheck()) {
+        atomic_store(&_unansweredPings, 0);
+        return;
+    }
+
+    // App-active guard.
+    BOOL(^activeCheck)(void) = self.isAppActiveBlock;
+    if (activeCheck && !activeCheck()) {
+        atomic_store(&_unansweredPings, 0);
+        return;
+    }
+
+    // Throttle: only one hang report per processing window.
+    if (atomic_load(&_hangReportedForCurrentWindow)) {
+        return;
+    }
+
+    int32_t pings = atomic_fetch_add(&_unansweredPings, 1) + 1;
+    if (pings < maxUnansweredPings) {
+        return;
+    }
+
+    // Claim the window so we only fire once per hang.
+    bool expected = false;
+    if (!atomic_compare_exchange_strong(&_hangReportedForCurrentWindow, &expected, true)) {
+        return;
+    }
+
+    NSTimeInterval duration = pings * BugSplatHangPollInterval(threshold);
+    [self notifyDelegateOfHangWithDuration:duration];
+}
+
+/// Called on the main thread when the ping block runs (i.e. main is responsive).
+/// Resets the unanswered-ping counter and, if a hang had been reported for the
+/// just-ended window, dispatches a recovery callback so the integrator can
+/// discard any persisted hang report.
+- (void)handleMainQueuePong {
+    atomic_store(&_unansweredPings, 0);
+    bool wasReported = atomic_exchange(&_hangReportedForCurrentWindow, false);
+    if (!wasReported) {
+        return;
+    }
+
+    id<BugSplatHangTrackerDelegate> delegate = self.delegate;
+    if (![delegate respondsToSelector:@selector(hangTrackerDidRecoverFromHang:)]) {
+        return;
+    }
+
+    __weak __typeof(self) weakSelf = self;
+    self.recoveryDispatcher(^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            [delegate hangTrackerDidRecoverFromHang:strongSelf];
+        }
+    });
+}
+
+#pragma mark - Notification
+
+- (void)notifyDelegateOfHangWithDuration:(NSTimeInterval)duration {
+    id<BugSplatHangTrackerDelegate> delegate = self.delegate;
+    if (![delegate respondsToSelector:@selector(hangTracker:didDetectHangWithDuration:appState:)]) {
+        return;
+    }
+
+    NSString *appState = [self currentAppStateDescription];
+    [delegate hangTracker:self didDetectHangWithDuration:duration appState:appState];
+}
+
+- (NSString *)currentAppStateDescription {
+    BOOL(^activeCheck)(void) = self.isAppActiveBlock;
+    if (!activeCheck) {
+        return @"unknown";
+    }
+    return activeCheck() ? @"active" : @"background";
+}
+
+@end

--- a/BugSplatHangTracker.m
+++ b/BugSplatHangTracker.m
@@ -6,14 +6,8 @@
 
 #import "BugSplatHangTracker.h"
 
-#import <CoreFoundation/CoreFoundation.h>
+#import <math.h>
 #import <stdatomic.h>
-#import <pthread.h>
-#import <mach/mach.h>
-
-#if TARGET_OS_IOS || TARGET_OS_TV
-#import <UIKit/UIKit.h>
-#endif
 
 static const NSTimeInterval kMinThresholdSeconds = 0.1;
 static const NSTimeInterval kMinPollIntervalSeconds = 0.1;
@@ -48,11 +42,17 @@ static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold)
 
 @implementation BugSplatHangTracker {
     // Number of consecutive watchdog polls during which the main thread has
-    // not serviced a dispatched ping. Each poll dispatches a ping block to the
-    // main queue; the ping block resets this counter to 0. If the counter
+    // not serviced a dispatched ping. Each poll increments this; the ping
+    // block, when serviced on the main queue, resets it to 0. If the counter
     // reaches the threshold-derived limit, the main thread has been blocked
     // for at least `thresholdSeconds`.
     _Atomic(int32_t) _unansweredPings;
+
+    // YES while a ping block is queued on the main queue but has not yet run.
+    // Gates dispatch so that during a long hang we don't accumulate an
+    // unbounded backlog of pending pings - a single outstanding ping is
+    // sufficient to detect responsiveness either way.
+    _Atomic(bool) _pingOutstanding;
 
     // Set to YES once a hang has been reported for the current window;
     // cleared by the next pong (which also triggers a recovery callback).
@@ -104,6 +104,7 @@ static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold)
             };
         }
         atomic_init(&_unansweredPings, 0);
+        atomic_init(&_pingOutstanding, false);
         atomic_init(&_hangReportedForCurrentWindow, false);
     }
     return self;
@@ -122,6 +123,7 @@ static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold)
     }
     self.running = YES;
     atomic_store(&_unansweredPings, 0);
+    atomic_store(&_pingOutstanding, false);
     atomic_store(&_hangReportedForCurrentWindow, false);
 
     NSThread *thread = [[NSThread alloc] initWithTarget:self
@@ -157,10 +159,14 @@ static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold)
 
     while (self.isRunning) {
         @autoreleasepool {
-            // Send a ping to the main queue. If the main thread is healthy it
-            // will service this block before the next poll; if it is hung the
-            // block will sit on the main queue and our counter will tick up.
-            self.pingDispatcher(ping);
+            // Send a ping to the main queue if there isn't one already in flight.
+            // A single outstanding ping is sufficient to observe responsiveness;
+            // dispatching on every poll during a long hang would accumulate an
+            // unbounded backlog that all flushes the moment main resumes.
+            bool wasOutstanding = atomic_exchange(&_pingOutstanding, true);
+            if (!wasOutstanding) {
+                self.pingDispatcher(ping);
+            }
 
             CFAbsoluteTime sleepStart = self.clockBlock();
             [NSThread sleepForTimeInterval:pollInterval];
@@ -228,6 +234,7 @@ static inline NSInteger BugSplatHangMaxUnansweredPings(NSTimeInterval threshold)
 /// just-ended window, dispatches a recovery callback so the integrator can
 /// discard any persisted hang report.
 - (void)handleMainQueuePong {
+    atomic_store(&_pingOutstanding, false);
     atomic_store(&_unansweredPings, 0);
     bool wasReported = atomic_exchange(&_hangReportedForCurrentWindow, false);
     if (!wasReported) {

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/BugSplatTest-SwiftUIApp.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/BugSplatTest-SwiftUIApp.swift
@@ -49,7 +49,12 @@ struct BugSplatTestSwiftUIApp: App {
         bugSplat.set("Launch Date <![CDATA[\(Date.now)]]> Value", for: "CDATAExample")
         bugSplat.set("<!-- 'value is > or < before' --> \(Date.now)", for: "CommentExample")
         bugSplat.set("This value will get XML escaping because of 'this' and & and < and >", for: "EscapingExample")
-    
+
+        // Opt in to fatal hang detection. When the main thread is blocked past the built-in
+        // threshold and the app is subsequently terminated without recovering, a hang report
+        // is uploaded on the next launch using the same pipeline as crash reports.
+        bugSplat.enableHangDetection = true
+
         // Don't forget to call start after you've finished configuring BugSplat
         bugSplat.start()
     }

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State var feedbackTitle = ""
     @State var feedbackDescription = ""
     @State var feedbackStatus: String?
+    @State var showHangConfirm = false
 
     let prop: Int? = nil
 
@@ -56,6 +57,14 @@ struct ContentView: View {
             .background(Color.accentColor)
             .cornerRadius(10)
 
+            Button("Simulate Hang") {
+                showHangConfirm = true
+            }
+            .padding()
+            .foregroundColor(.white)
+            .background(Color.orange)
+            .cornerRadius(10)
+
             Button("Send Feedback") {
                 showFeedbackAlert = true
             }
@@ -85,6 +94,21 @@ struct ContentView: View {
             Button("Send") { sendFeedback() }
             Button("Cancel", role: .cancel) { }
         }
+        .alert("Simulate Fatal Hang?", isPresented: $showHangConfirm) {
+            Button("Hang App", role: .destructive) { simulateHang() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("The main thread will be blocked indefinitely. The UI will freeze and the only way to recover is to force-quit the app.\n\nOn a real device, swipe up from the app switcher. On the iOS Simulator, swipe-up only backgrounds the app - run `xcrun simctl terminate booted com.bugsplat.BugSplatTest-SwiftUI` from a terminal instead.\n\nOn the next launch, a fatal-hang report will be uploaded. Continue?")
+        }
+    }
+
+    func simulateHang() {
+        // Blocks the main thread forever so the only way to exit is to force-quit
+        // the app. That produces a fatal-hang report that is uploaded on the next
+        // launch. If the main thread were allowed to recover, the persisted report
+        // would be discarded because non-fatal hangs are intentionally not reported.
+        print("BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.")
+        while true { }
     }
 
     func update(attribute: String, value: String?) {

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -108,7 +108,10 @@ struct ContentView: View {
         // launch. If the main thread were allowed to recover, the persisted report
         // would be discarded because non-fatal hangs are intentionally not reported.
         print("BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.")
-        while true { }
+        // Sleep inside the loop instead of busy-spinning so the device
+        // doesn't melt while the demo is running - the main thread is
+        // still blocked, which is what the hang detector cares about.
+        while true { Thread.sleep(forTimeInterval: 1.0) }
     }
 
     func update(attribute: String, value: String?) {

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/AppDelegate.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/AppDelegate.m
@@ -37,7 +37,10 @@
     [[BugSplat shared] setValue:[NSString stringWithFormat:@"Launch Date <![CDATA[%@]]> Value", [NSDate date]] forAttribute:@"CDATAExample"];
     [[BugSplat shared] setValue:[NSString stringWithFormat:@"<!-- 'value is > or < before' --> %@", [NSDate date]] forAttribute:@"CommentExample"];
     [[BugSplat shared] setValue:@"This value will get XML escaping because of 'this' and & and < and >" forAttribute:@"EscapingExample"];
-    
+
+    // Opt in to fatal hang detection.
+    [[BugSplat shared] setEnableHangDetection:YES];
+
     // Don't forget to call start after you've finished configuring BugSplat
     [[BugSplat shared] start];
 

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -33,11 +33,39 @@
         [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
         [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:60]
     ]];
+
+    // Add a "Simulate Hang" button for demoing fatal-hang detection.
+    UIButton *hangButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [hangButton setTitle:@"Simulate Hang" forState:UIControlStateNormal];
+    [hangButton addTarget:self action:@selector(simulateHang) forControlEvents:UIControlEventTouchUpInside];
+    hangButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:hangButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [hangButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [hangButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:100]
+    ]];
 }
 
 - (IBAction)crashApp:(id)sender {
     NSNumber *number = [self.array objectAtIndex:2];
     NSLog(@"number = %ld", [number longValue]);
+}
+
+- (void)simulateHang {
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:@"Simulate Fatal Hang?"
+                         message:@"The main thread will be blocked indefinitely. The UI will freeze and the only way to recover is to force-quit the app.\n\nOn a real device, swipe up from the app switcher. On the iOS Simulator, swipe-up only backgrounds the app - run `xcrun simctl terminate booted com.bugsplat.BugSplatTest-UIKit-ObjC` from a terminal instead.\n\nOn the next launch, a fatal-hang report will be uploaded. Continue?"
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Hang App" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        // Blocks the main thread forever so the only way to exit is to force-quit the
+        // app. That produces a fatal-hang report that is uploaded on the next launch.
+        // If the main thread were allowed to recover, the persisted report would be
+        // discarded because non-fatal hangs are intentionally not reported.
+        NSLog(@"BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.");
+        while (1) { }
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)showFeedbackDialog {

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -63,7 +63,10 @@
         // If the main thread were allowed to recover, the persisted report would be
         // discarded because non-fatal hangs are intentionally not reported.
         NSLog(@"BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.");
-        while (1) { }
+        // Sleep inside the loop instead of busy-spinning so the device
+        // doesn't melt while the demo is running - the main thread is
+        // still blocked, which is what the hang detector cares about.
+        while (1) { [NSThread sleepForTimeInterval:1.0]; }
     }]];
     [self presentViewController:alert animated:YES completion:nil];
 }

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/AppDelegate.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/AppDelegate.swift
@@ -35,6 +35,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         bugSplat.set("<!-- 'value is > or < before' --> \(Date.now)", for: "CommentExample")
         bugSplat.set("This value will get XML escaping because of 'this' and & and < and >", for: "EscapingExample")
 
+        // Opt in to fatal hang detection.
+        bugSplat.enableHangDetection = true
+
         // Don't forget to call start after you've finished configuring BugSplat
         bugSplat.start()
         

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -62,7 +62,10 @@ class ViewController: UIViewController {
             // launch. If the main thread were allowed to recover, the persisted report
             // would be discarded because non-fatal hangs are intentionally not reported.
             print("BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.")
-            while true { }
+            // Sleep inside the loop instead of busy-spinning so the device
+            // doesn't melt while the demo is running - the main thread is
+            // still blocked, which is what the hang detector cares about.
+            while true { Thread.sleep(forTimeInterval: 1.0) }
         })
         present(alert, animated: true)
     }

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -31,12 +31,40 @@ class ViewController: UIViewController {
             feedbackButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             feedbackButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 60)
         ])
+
+        // Add a "Simulate Hang" button for demoing fatal-hang detection.
+        let hangButton = UIButton(type: .system)
+        hangButton.setTitle("Simulate Hang", for: .normal)
+        hangButton.addTarget(self, action: #selector(simulateHang), for: .touchUpInside)
+        hangButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hangButton)
+        NSLayoutConstraint.activate([
+            hangButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            hangButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 100)
+        ])
     }
 
     @IBAction func crashApp(_ sender: Any) {
         // intentially crash app here to demonstrate BugSplat's crash reporting capabilities
         let description = nonOptional!.debugDescription
         print(description)
+    }
+
+    @objc func simulateHang() {
+        let alert = UIAlertController(
+            title: "Simulate Fatal Hang?",
+            message: "The main thread will be blocked indefinitely. The UI will freeze and the only way to recover is to force-quit the app.\n\nOn a real device, swipe up from the app switcher. On the iOS Simulator, swipe-up only backgrounds the app - run `xcrun simctl terminate booted com.bugsplat.BugSplatTest-UIKit-Swift` from a terminal instead.\n\nOn the next launch, a fatal-hang report will be uploaded. Continue?",
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Hang App", style: .destructive) { _ in
+            // Blocks the main thread forever so the only way to exit is to force-quit
+            // the app. That produces a fatal-hang report that is uploaded on the next
+            // launch. If the main thread were allowed to recover, the persisted report
+            // would be discarded because non-fatal hangs are intentionally not reported.
+            print("BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.")
+            while true { }
+        })
+        present(alert, animated: true)
     }
 
     @objc func showFeedbackDialog() {

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatInit.mm
@@ -65,6 +65,9 @@ int bugSplatInit(const char * bugSplatDatabase)
         // Set the BugSplatDatabase name before calling start
         [[BugSplat shared] setBugSplatDatabase:databaseName];
 
+        // Opt in to fatal hang detection.
+        [[BugSplat shared] setEnableHangDetection:YES];
+
         // Don't forget to call start after you've finished configuring BugSplat
         [[BugSplat shared] start];
 

--- a/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/main.cpp
+++ b/Example_Apps/BugSplatTest-macOS-Tool-CPlusPlus/BugSplatTest-macOS-Tool-CPlusPlus/main.cpp
@@ -6,6 +6,8 @@
 //
 
 #include <iostream>
+#include <thread>
+#include <chrono>
 #include "BugSplatInit.hpp"
 
 int setAttributeAndValue()
@@ -58,9 +60,33 @@ int checkInput(std::string input)
     {
         return sendFeedback();
     }
+    else if (input == "hang")
+    {
+        std::cout << "\nAbout to simulate a fatal main-thread hang.\n"
+                  << "The process will stop responding and the only way to exit is to kill it\n"
+                  << "(Ctrl+C, or `kill -9 <pid>` from another shell). On the next run, a fatal-hang\n"
+                  << "report will be uploaded.\n"
+                  << "Type 'yes' to continue, anything else to cancel: " << std::flush;
+        std::string confirm;
+        std::getline(std::cin, confirm);
+        if (confirm != "yes") {
+            std::cout << "Cancelled." << std::endl;
+            return 0;
+        }
+        // Blocks the main thread forever. If the main thread were allowed to recover,
+        // the persisted report would be discarded because non-fatal hangs are
+        // intentionally not reported.
+        //
+        // sleep_for keeps the loop observably side-effectful so the C++ forward-progress
+        // rule cannot let an optimizer elide it; a bare `while (true) {}` is UB in C++.
+        std::cout << "Simulating main-thread hang. Kill the process to see a fatal-hang report uploaded on the next run." << std::endl;
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
     else
     {
-        std::cout << "Unknown command. Try: 'seg fault', 'divide by zero', 'set', 'feedback', or 'q' to quit" << std::endl;
+        std::cout << "Unknown command. Try: 'seg fault', 'divide by zero', 'set', 'feedback', 'hang', or 'q' to quit" << std::endl;
     }
 
     return 0;

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/AppDelegate.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/AppDelegate.m
@@ -41,7 +41,10 @@
     [[BugSplat shared] setValue:[NSString stringWithFormat:@"Launch Date <![CDATA[%@]]> Value", [NSDate date]] forAttribute:@"CDATAExample"];
     [[BugSplat shared] setValue:[NSString stringWithFormat:@"<!-- 'value is > or < before' --> %@", [NSDate date]] forAttribute:@"CommentExample"];
     [[BugSplat shared] setValue:@"This value will get XML escaping because of 'this' and & and < and >" forAttribute:@"EscapingExample"];
-    
+
+    // Opt in to fatal hang detection.
+    [[BugSplat shared] setEnableHangDetection:YES];
+
     // Don't forget to call start after you've finished configuring BugSplat
     [[BugSplat shared] start];
 }

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -30,6 +30,39 @@
         [feedbackButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
         [feedbackButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:40]
     ]];
+
+    // Add a "Simulate Hang" button for demoing fatal-hang detection.
+    NSButton *hangButton = [[NSButton alloc] initWithFrame:NSZeroRect];
+    hangButton.title = @"Simulate Hang";
+    hangButton.bezelStyle = NSBezelStyleRounded;
+    hangButton.target = self;
+    hangButton.action = @selector(simulateHang:);
+    hangButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:hangButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [hangButton.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [hangButton.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor constant:80]
+    ]];
+}
+
+- (IBAction)simulateHang:(id)sender {
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = @"Simulate Fatal Hang?";
+    alert.informativeText = @"The main thread will be blocked indefinitely. The UI will freeze and the only way to recover is to force-quit the app (Cmd+Option+Esc, then Force Quit) or kill the process from a terminal (`killall -9 BugSplatTest-macOS-UIKit-ObjC`). On the next launch, a fatal-hang report will be uploaded. Continue?";
+    alert.alertStyle = NSAlertStyleWarning;
+    [alert addButtonWithTitle:@"Hang App"];
+    [alert addButtonWithTitle:@"Cancel"];
+
+    if ([alert runModal] != NSAlertFirstButtonReturn) {
+        return;
+    }
+
+    // Blocks the main thread forever so the only way to exit is to force-quit the
+    // app. That produces a fatal-hang report that is uploaded on the next launch.
+    // If the main thread were allowed to recover, the persisted report would be
+    // discarded because non-fatal hangs are intentionally not reported.
+    NSLog(@"BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.");
+    while (1) { }
 }
 
 

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -62,7 +62,10 @@
     // If the main thread were allowed to recover, the persisted report would be
     // discarded because non-fatal hangs are intentionally not reported.
     NSLog(@"BugSplat sample: Simulating main-thread hang. Force-quit to see a fatal-hang report on the next launch.");
-    while (1) { }
+    // Sleep inside the loop instead of busy-spinning so the device
+    // doesn't melt while the demo is running - the main thread is
+    // still blocked, which is what the hang detector cares about.
+    while (1) { [NSThread sleepForTimeInterval:1.0]; }
 }
 
 

--- a/Tests/BugSplatTests/BugSplatHangPersistenceTests.m
+++ b/Tests/BugSplatTests/BugSplatHangPersistenceTests.m
@@ -1,0 +1,205 @@
+//
+//  BugSplatHangPersistenceTests.m
+//  BugSplatTests
+//
+//  Integration-style tests covering the hang delegate's disk persistence:
+//  on hang, a .crash + .meta pair is written into the crashes directory;
+//  on recovery, those files are removed. Uses a real PLCrashReporter to
+//  generate the live report.
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <TargetConditionals.h>
+#import <XCTest/XCTest.h>
+
+#import <BugSplat/BugSplat.h>
+#import "BugSplat+Testing.h"
+
+// Keys shared with BugSplat.m. Duplicated here rather than exposed via a
+// testing header because they are an implementation detail the backend also
+// understands via well-known strings.
+static NSString *const kAttributesKey = @"attributes";
+static NSString *const kDatabaseKey = @"database";
+static NSString *const kUserSubmittedKey = @"userSubmitted";
+static NSString *const kTimestampKey = @"timestamp";
+static NSString *const kHangAttrDurationMs = @"bugsplat-hang-duration-ms";
+static NSString *const kHangAttrAppState = @"bugsplat-hang-app-state";
+static NSString *const kHangAttrDetectedAt = @"bugsplat-hang-detected-at";
+static NSString *const kHangAttrLaunchId = @"bugsplat-hang-launch-id";
+
+
+@interface BugSplatHangPersistenceTests : XCTestCase
+@property (nonatomic, strong) BugSplat *bugSplat;
+@property (nonatomic, copy, nullable) NSString *filenameToCleanup;
+@end
+
+@implementation BugSplatHangPersistenceTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Use a regular BugSplat instance (not testInstance) so it carries a real
+    // PLCrashReporter - needed for the live-report capture path.
+    self.bugSplat = [[BugSplat alloc] init];
+    self.bugSplat.bugSplatDatabase = @"hangtestdb";
+    self.bugSplat.applicationName = @"HangTest";
+    self.bugSplat.applicationVersion = @"1.0";
+    self.bugSplat.enableHangDetection = YES;
+    [self.bugSplat setupHangInfrastructureForTesting];
+}
+
+- (void)tearDown
+{
+    NSString *filename = self.filenameToCleanup;
+    if (filename) {
+        [self removeReportFilesForFilename:filename];
+    }
+    self.filenameToCleanup = nil;
+    self.bugSplat = nil;
+    [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (void)removeReportFilesForFilename:(NSString *)filename
+{
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    for (NSString *ext in @[@"crash", @"meta"]) {
+        NSString *path = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:ext];
+        if ([fm fileExistsAtPath:path]) {
+            [fm removeItemAtPath:path error:nil];
+        }
+    }
+}
+
+- (void)drainHangQueue
+{
+    dispatch_queue_t queue = [self.bugSplat hangQueueForTesting];
+    XCTAssertNotNil(queue);
+    dispatch_sync(queue, ^{});
+}
+
+#pragma mark - Tests
+
+- (void)testHangDelegate_WritesCrashAndMetaFiles
+{
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:3.5 appState:@"active"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename, @"Hang delegate should have persisted a report");
+    XCTAssertTrue([filename hasSuffix:@"-hang"], @"Hang report filename should carry the -hang suffix");
+    self.filenameToCleanup = filename;
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *crashPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"crash"];
+    NSString *metaPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"meta"];
+
+    NSFileManager *fm = [NSFileManager defaultManager];
+    XCTAssertTrue([fm fileExistsAtPath:crashPath]);
+    XCTAssertTrue([fm fileExistsAtPath:metaPath]);
+}
+
+- (void)testHangDelegate_ReportTextContainsExceptionName
+{
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:3.5 appState:@"active"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename);
+    self.filenameToCleanup = filename;
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *crashPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"crash"];
+    NSString *crashText = [NSString stringWithContentsOfFile:crashPath encoding:NSUTF8StringEncoding error:nil];
+    XCTAssertNotNil(crashText);
+
+    XCTAssertTrue([crashText containsString:@"App Hang (Fatal)"],
+                  @"Report text should carry the App Hang (Fatal) exception name; got:\n%@", crashText);
+    XCTAssertTrue([crashText containsString:@"Main thread unresponsive for 3500 ms"],
+                  @"Report text should carry the exception reason with duration; got:\n%@", crashText);
+}
+
+- (void)testHangDelegate_MetadataHasDatabaseAndUserSubmittedFlag
+{
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:2.0 appState:@"active"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename);
+    self.filenameToCleanup = filename;
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *metaPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"meta"];
+    NSDictionary *meta = [NSDictionary dictionaryWithContentsOfFile:metaPath];
+    XCTAssertNotNil(meta);
+
+    XCTAssertEqualObjects(meta[kDatabaseKey], @"hangtestdb");
+    XCTAssertEqualObjects(meta[kUserSubmittedKey], @YES);
+    XCTAssertNotNil(meta[kTimestampKey]);
+}
+
+- (void)testHangDelegate_MetadataContainsHangAttributes
+{
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:2.5 appState:@"background"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename);
+    self.filenameToCleanup = filename;
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *metaPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"meta"];
+    NSDictionary *meta = [NSDictionary dictionaryWithContentsOfFile:metaPath];
+    NSDictionary *attributes = meta[kAttributesKey];
+    XCTAssertNotNil(attributes);
+
+    XCTAssertEqualObjects(attributes[kHangAttrDurationMs], @"2500");
+    XCTAssertEqualObjects(attributes[kHangAttrAppState], @"background");
+    XCTAssertNotNil(attributes[kHangAttrDetectedAt]);
+    XCTAssertNotNil(attributes[kHangAttrLaunchId]);
+}
+
+- (void)testHangDelegate_RecoveryRemovesPersistedFiles
+{
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:3.0 appState:@"active"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename);
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *crashPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"crash"];
+    NSString *metaPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"meta"];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    XCTAssertTrue([fm fileExistsAtPath:crashPath]);
+
+    // Main thread "recovers" - persisted files should be deleted.
+    [self.bugSplat hangTrackerDidRecoverFromHang:nil];
+    [self drainHangQueue];
+
+    XCTAssertFalse([fm fileExistsAtPath:crashPath], @"Crash file should be deleted on recovery");
+    XCTAssertFalse([fm fileExistsAtPath:metaPath], @"Meta file should be deleted on recovery");
+    XCTAssertNil([self.bugSplat currentHangFilename]);
+}
+
+- (void)testHangDelegate_FallsThroughWithoutAppState
+{
+    // Pass a nil-safe "unknown" value - delegate should accept it and persist fine.
+    [self.bugSplat hangTracker:nil didDetectHangWithDuration:2.0 appState:@"unknown"];
+    [self drainHangQueue];
+
+    NSString *filename = [self.bugSplat currentHangFilename];
+    XCTAssertNotNil(filename);
+    self.filenameToCleanup = filename;
+
+    NSString *dir = [self.bugSplat crashesDirectoryPath];
+    NSString *metaPath = [[dir stringByAppendingPathComponent:filename] stringByAppendingPathExtension:@"meta"];
+    NSDictionary *meta = [NSDictionary dictionaryWithContentsOfFile:metaPath];
+    NSDictionary *attributes = meta[kAttributesKey];
+    XCTAssertEqualObjects(attributes[kHangAttrAppState], @"unknown");
+}
+
+@end

--- a/Tests/BugSplatTests/BugSplatHangTrackerTests.m
+++ b/Tests/BugSplatTests/BugSplatHangTrackerTests.m
@@ -1,0 +1,275 @@
+//
+//  BugSplatHangTrackerTests.m
+//  BugSplatTests
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import "BugSplatHangTracker.h"
+
+
+/// Private testing surface. Implementations live in `BugSplatHangTracker.m`;
+/// this category just makes them visible to the test compilation unit so we can
+/// drive the state machine without spawning a real watchdog thread or relying
+/// on real wall-clock timing.
+@interface BugSplatHangTracker (Testing)
+- (instancetype)initWithThresholdSeconds:(NSTimeInterval)thresholdSeconds
+                                 delegate:(id<BugSplatHangTrackerDelegate>)delegate
+                   isDebuggerAttachedBlock:(BOOL(^)(void))isDebuggerAttachedBlock
+                         isAppActiveBlock:(BOOL(^)(void))isAppActiveBlock
+                                clockBlock:(CFAbsoluteTime(^)(void))clockBlock
+                       recoveryDispatcher:(void(^)(dispatch_block_t))recoveryDispatcher
+                            pingDispatcher:(void(^)(dispatch_block_t))pingDispatcher;
+- (void)_processPollWithActualSleepDuration:(NSTimeInterval)actualSleep;
+- (void)handleMainQueuePong;
+@end
+
+
+@interface MockHangTrackerDelegate : NSObject <BugSplatHangTrackerDelegate>
+@property (atomic, assign) NSInteger hangCount;
+@property (atomic, assign) NSInteger recoverCount;
+@property (atomic, assign) NSTimeInterval lastDuration;
+@property (atomic, copy, nullable) NSString *lastAppState;
+@end
+
+@implementation MockHangTrackerDelegate
+
+- (void)hangTracker:(BugSplatHangTracker *)tracker
+didDetectHangWithDuration:(NSTimeInterval)duration
+            appState:(NSString *)appState
+{
+    self.hangCount += 1;
+    self.lastDuration = duration;
+    self.lastAppState = appState;
+}
+
+- (void)hangTrackerDidRecoverFromHang:(BugSplatHangTracker *)tracker
+{
+    self.recoverCount += 1;
+}
+
+@end
+
+
+@interface BugSplatHangTrackerTests : XCTestCase
+@property (nonatomic, strong) MockHangTrackerDelegate *mockDelegate;
+@end
+
+@implementation BugSplatHangTrackerTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.mockDelegate = [[MockHangTrackerDelegate alloc] init];
+}
+
+- (BugSplatHangTracker *)trackerWithThreshold:(NSTimeInterval)threshold
+                              debuggerAttached:(BOOL)debuggerAttached
+                                     appActive:(BOOL)appActive
+{
+    // Synchronous recovery dispatcher: tests observe recoverCount inline.
+    void(^synchronousRecovery)(dispatch_block_t) = ^(dispatch_block_t b) { b(); };
+    // No-op ping dispatcher: tests manually drive pongs via -handleMainQueuePong
+    // so a "hung" main thread is simulated by simply not calling it.
+    void(^noopPing)(dispatch_block_t) = ^(dispatch_block_t b) { /* drop */ };
+    // Tests don't need real wall-clock time for the new design; the per-poll
+    // logic takes the actual-sleep duration as a parameter. Return 0 just so
+    // clockBlock isn't nil if production code ever reaches it.
+    CFAbsoluteTime(^zeroClock)(void) = ^{ return (CFAbsoluteTime)0; };
+    return [[BugSplatHangTracker alloc] initWithThresholdSeconds:threshold
+                                                        delegate:self.mockDelegate
+                                          isDebuggerAttachedBlock:^BOOL { return debuggerAttached; }
+                                                isAppActiveBlock:^BOOL { return appActive; }
+                                                       clockBlock:zeroClock
+                                              recoveryDispatcher:synchronousRecovery
+                                                   pingDispatcher:noopPing];
+}
+
+/// Simulate N consecutive polls where the main thread never serviced the ping.
+- (void)pollTracker:(BugSplatHangTracker *)tracker times:(NSInteger)n
+{
+    // Use a normal (non-suspension) sleep duration so the guard doesn't reset.
+    NSTimeInterval normalSleep = tracker.thresholdSeconds / 5.0;
+    for (NSInteger i = 0; i < n; i++) {
+        [tracker _processPollWithActualSleepDuration:normalSleep];
+    }
+}
+
+#pragma mark - Initializer
+
+- (void)testInit_ClampsBelowMinimumThreshold
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:0.01 debuggerAttached:NO appActive:YES];
+    XCTAssertGreaterThanOrEqual(tracker.thresholdSeconds, 0.1);
+}
+
+- (void)testInit_StoresThreshold
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+    XCTAssertEqualWithAccuracy(tracker.thresholdSeconds, 2.0, 0.0001);
+}
+
+- (void)testInit_IsNotRunning
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+    XCTAssertFalse(tracker.isRunning);
+}
+
+#pragma mark - Detection
+
+- (void)testDetectsHang_WhenMainNeverServicesPings
+{
+    // threshold=2.0, pollInterval=0.4 -> 5 unanswered polls = hang.
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    [self pollTracker:tracker times:4];
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+
+    [self pollTracker:tracker times:1];
+    XCTAssertEqual(self.mockDelegate.hangCount, 1);
+    XCTAssertGreaterThanOrEqual(self.mockDelegate.lastDuration, 2.0);
+    XCTAssertEqualObjects(self.mockDelegate.lastAppState, @"active");
+}
+
+- (void)testDoesNotDetect_WhenMainServicesPingsEachRound
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    // Each poll is followed by a pong - main is responsive.
+    for (NSInteger i = 0; i < 10; i++) {
+        [self pollTracker:tracker times:1];
+        [tracker handleMainQueuePong];
+    }
+
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+}
+
+- (void)testDoesNotDetect_WhenDebuggerAttached
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:YES appActive:YES];
+
+    [self pollTracker:tracker times:10];
+
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+}
+
+- (void)testDoesNotDetect_WhenAppInactive
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:NO];
+
+    [self pollTracker:tracker times:10];
+
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+}
+
+#pragma mark - Recovery
+
+- (void)testRecovery_FiresAfterPongFollowingHang
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    [self pollTracker:tracker times:5];
+    XCTAssertEqual(self.mockDelegate.hangCount, 1);
+    XCTAssertEqual(self.mockDelegate.recoverCount, 0);
+
+    // Main thread services a ping -> recovery fires.
+    [tracker handleMainQueuePong];
+    XCTAssertEqual(self.mockDelegate.recoverCount, 1);
+}
+
+- (void)testRecovery_DoesNotFireWithoutPriorHang
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    [tracker handleMainQueuePong];
+    XCTAssertEqual(self.mockDelegate.recoverCount, 0);
+}
+
+#pragma mark - Throttle
+
+- (void)testThrottle_OnlyOneHangPerProcessingWindow
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    // Many extra polls inside the same hung window must not refire.
+    [self pollTracker:tracker times:20];
+
+    XCTAssertEqual(self.mockDelegate.hangCount, 1);
+}
+
+- (void)testThrottle_NewWindowCanFireAgain
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    [self pollTracker:tracker times:5];
+    XCTAssertEqual(self.mockDelegate.hangCount, 1);
+
+    // Main resumes long enough for one pong, then hangs again.
+    [tracker handleMainQueuePong];
+    [self pollTracker:tracker times:5];
+    XCTAssertEqual(self.mockDelegate.hangCount, 2);
+}
+
+#pragma mark - Suspension guard
+
+- (void)testSuspensionGuard_ResetsCounterAfterLargeSleep
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    // Accumulate some unanswered pings, but not yet enough to fire.
+    [self pollTracker:tracker times:3];
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+
+    // A long sleep (e.g. device suspended) - guard resets the counter.
+    [tracker _processPollWithActualSleepDuration:30.0];
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+
+    // The next few polls should not be enough to fire because the counter
+    // was reset by the suspension guard.
+    [self pollTracker:tracker times:3];
+    XCTAssertEqual(self.mockDelegate.hangCount, 0);
+}
+
+- (void)testSuspensionGuard_NormalSleepDoesNotReset
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+
+    // Sleep durations that hover slightly over the poll interval should not
+    // count as suspension - real hangs need to be detectable across noisy
+    // scheduling.
+    NSTimeInterval slightlyLong = 0.45;
+    for (NSInteger i = 0; i < 5; i++) {
+        [tracker _processPollWithActualSleepDuration:slightlyLong];
+    }
+    XCTAssertEqual(self.mockDelegate.hangCount, 1);
+}
+
+#pragma mark - Start / stop wiring (smoke)
+
+- (void)testStart_SetsRunning
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+    [tracker start];
+    XCTAssertTrue(tracker.isRunning);
+    [tracker stop];
+}
+
+- (void)testStop_ClearsRunning
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+    [tracker start];
+    [tracker stop];
+    XCTAssertFalse(tracker.isRunning);
+}
+
+- (void)testStop_IsIdempotent
+{
+    BugSplatHangTracker *tracker = [self trackerWithThreshold:2.0 debuggerAttached:NO appActive:YES];
+    [tracker start];
+    [tracker stop];
+    XCTAssertNoThrow([tracker stop]);
+}
+
+@end


### PR DESCRIPTION
Replaces #52 with a squashed, focused history. PR #52 had ~13 commits showing the journey (initial implementation → race fix → CI flake → testability refactor → final simplification); the diff and final design are unchanged but the review experience is now two logical commits.

## Summary

Opt-in detection and reporting of fatal main-thread hangs on iOS, tvOS, and macOS. Uses the standard "watchdog pings the main queue and counts unanswered pings" pattern — no CFRunLoopObserver, no generation counters, no special-case state machine.

## Public API

Two new properties on \`BugSplat\`, set before calling \`-start\`:

- \`enableHangDetection: BOOL\` (default \`NO\`) — opt in
- \`hangDetectionThreshold: NSTimeInterval\` (default \`2.0\`) — unresponsive duration that counts as a hang; clamped to \`>= 0.1s\`

When enabled, \`-start\` must be called on the main thread so the main thread's Mach port can be captured for the hang report. Detection is suppressed while a debugger is attached or the app is inactive (iOS/tvOS background). No-op inside app extensions.

## Design

- Dedicated low-QoS watchdog \`NSThread\` polls every \`threshold / 5\` seconds (clamped to \`>= 100ms\`).
- Each poll \`dispatch_async\`s a small ping block to \`dispatch_get_main_queue()\` and increments an atomic counter.
- The ping block resets the counter; if main is hung the counter ticks up until it covers \`thresholdSeconds\`, then the delegate is notified.
- Recovery fires on the first pong after a hang was reported, so the integrator can discard a persisted report when main resumes.
- Suspension guard: if the watchdog's actual sleep duration exceeds \`threshold * 2\`, the device was suspended and the counter is reset.

## Persistence

\`BugSplat\` captures the hang as a synthetic \`PLCrashReport\` live report (marking main as the crashed thread via the captured Mach port) and writes it plus a \`.meta\` sidecar into the crashes directory. The next-launch scanner picks it up via the existing crash-upload pipeline. Reports carry the exception name \`App Hang (Fatal)\` and \`bugsplat-hang-*\` attributes (duration, detection time, app state, launch id).

If the meta-write fails, the just-written \`.crash\` is removed so no orphan can survive to the next launch and bypass the silent-submit flag.

## Tests

- \`BugSplatHangTrackerTests\` drives the state machine deterministically via injected clock / dispatch / ping blocks — 16 tests, each < 10ms, no real-time dependency.
- \`BugSplatHangPersistenceTests\` covers BugSplat-side persistence (file layout, metadata shape, recovery cleanup).

## Sample apps

Each example app (SwiftUI, UIKit-Swift, UIKit-ObjC, macOS-UIKit-ObjC, macOS C++ CLI) gets a "Simulate Hang" demo that blocks the main thread forever; the next launch uploads the fatal-hang report.

## Test plan

- [x] iOS Tests pass locally (\`xcodebuild test ... -scheme BugSplatIOSTests\`)
- [x] macOS Tests pass locally (\`xcodebuild test ... -scheme BugSplatMacTests\`)
- [x] CI green on this branch
- [x] Copilot review (re-requested for the squashed version)
- [ ] Run "Simulate Hang" in one of the sample apps end-to-end and confirm the next-launch upload

## Related

- Closes #52 (squashed)
- Docs PR: BugSplat-Git/bugsplat-docs#154

🤖 Generated with [Claude Code](https://claude.com/claude-code)