### PR TITLE
feat: redesigned User Feedback sheet + thank-you screen

### DIFF
--- a/BugSplat.h
+++ b/BugSplat.h
@@ -17,6 +17,7 @@ FOUNDATION_EXPORT const unsigned char BugSplatVersionString[];
 
 #import <BugSplat/BugSplatDelegate.h>
 #import <BugSplat/BugSplatAttachment.h>
+#import <BugSplat/BugSplatFeedbackResult.h>
 #if TARGET_OS_OSX
 #import <BugSplat/BugSplatMac.h>
 #endif
@@ -267,6 +268,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param attachments Optional array of file attachments to include with the feedback.
  * @param completion Optional completion handler called when the upload finishes.
  *                   The error parameter is nil on success.
+ *
+ * @note To send custom attributes with the feedback, or to receive the report id
+ *       of the submitted feedback, use
+ *       `-postFeedback:description:userName:userEmail:appKey:attributes:attachments:completion:`.
  */
 - (void)postFeedback:(NSString *)title
          description:(nullable NSString *)description
@@ -276,6 +281,40 @@ NS_ASSUME_NONNULL_BEGIN
          attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
           completion:(nullable void (^)(NSError * _Nullable error))completion
     NS_SWIFT_NAME(postFeedback(title:description:userName:userEmail:appKey:attachments:completion:));
+
+/**
+ * Submits user feedback (non-crash) to BugSplat, with custom attributes, and reports
+ * the resulting report id.
+ *
+ * Behaves identically to
+ * `-postFeedback:description:userName:userEmail:appKey:attachments:completion:` with
+ * two additions:
+ *  - the supplied `attributes` are sent with the feedback and are searchable in the
+ *    BugSplat dashboard, and
+ *  - on success the completion handler receives a `BugSplatFeedbackResult` containing
+ *    the report id (`crashId`) and `infoUrl` of the submitted feedback.
+ *
+ * @param title The feedback title (required).
+ * @param description Optional description providing additional detail.
+ * @param userName Optional user name. Falls back to the `userName` property if nil.
+ * @param userEmail Optional user email. Falls back to the `userEmail` property if nil.
+ * @param appKey Optional application key. Falls back to the `appKey` property if nil.
+ * @param attributes Optional custom string key/value attributes to associate with the
+ *                   feedback, e.g. @{@"category": @"Bug"}.
+ * @param attachments Optional array of file attachments to include with the feedback.
+ * @param completion Optional completion handler called when the upload finishes.
+ *                   On success, `result` is non-nil and `error` is nil.
+ *                   On failure, `result` is nil and `error` is set.
+ */
+- (void)postFeedback:(NSString *)title
+         description:(nullable NSString *)description
+            userName:(nullable NSString *)userName
+           userEmail:(nullable NSString *)userEmail
+              appKey:(nullable NSString *)appKey
+          attributes:(nullable NSDictionary<NSString *, NSString *> *)attributes
+         attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
+          completion:(nullable void (^)(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error))completion
+    NS_SWIFT_NAME(postFeedback(title:description:userName:userEmail:appKey:attributes:attachments:completion:));
 
 // macOS specific API
 #if TARGET_OS_OSX

--- a/BugSplat.m
+++ b/BugSplat.m
@@ -1264,7 +1264,7 @@ didDetectHangWithDuration:(NSTimeInterval)duration
                             crashFilename:@"crash.crashlog"
                               attachments:attachments
                                  metadata:uploadMetadata
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) return;
         
@@ -1335,6 +1335,32 @@ didDetectHangWithDuration:(NSTimeInterval)duration
          attachments:(NSArray<BugSplatAttachment *> *)attachments
           completion:(void (^)(NSError * _Nullable error))completion
 {
+    // Backward-compatible shim: delegate to the attributes/result variant and adapt
+    // the result-carrying completion down to the historical error-only signature.
+    [self postFeedback:title
+           description:description
+              userName:userName
+             userEmail:userEmail
+                appKey:appKey
+            attributes:nil
+           attachments:attachments
+            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        if (completion)
+        {
+            completion(error);
+        }
+    }];
+}
+
+- (void)postFeedback:(NSString *)title
+         description:(NSString *)description
+            userName:(NSString *)userName
+           userEmail:(NSString *)userEmail
+              appKey:(NSString *)appKey
+          attributes:(NSDictionary<NSString *, NSString *> *)attributes
+         attachments:(NSArray<BugSplatAttachment *> *)attachments
+          completion:(void (^)(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error))completion
+{
     BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
     metadata.database = self.bugSplatDatabase;
     metadata.applicationName = self.resolvedApplicationName;
@@ -1345,6 +1371,7 @@ didDetectHangWithDuration:(NSTimeInterval)duration
     metadata.applicationKey = appKey ?: self.appKey;
     metadata.notes = self.notes;
     metadata.crashTypeId = @"36";
+    metadata.attributes = attributes;
 
     [self.uploadService uploadFeedback:title description:description attachments:attachments metadata:metadata completion:completion];
 }

--- a/BugSplat.xcodeproj/project.pbxproj
+++ b/BugSplat.xcodeproj/project.pbxproj
@@ -27,6 +27,12 @@
 		63E233822B9710420066C7FC /* BugSplatAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 63E2337C2B9710420066C7FC /* BugSplatAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63E233842B9711AB0066C7FC /* BugSplatAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 63E2337C2B9710420066C7FC /* BugSplatAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63E233852B9711B10066C7FC /* BugSplatAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 63E2337A2B9710410066C7FC /* BugSplatAttachment.m */; };
+		FEEDBAC000000000000000F3 /* BugSplatFeedbackResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F2 /* BugSplatFeedbackResult.m */; };
+		FEEDBAC000000000000000F4 /* BugSplatFeedbackResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F2 /* BugSplatFeedbackResult.m */; };
+		FEEDBAC000000000000000F5 /* BugSplatFeedbackResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F2 /* BugSplatFeedbackResult.m */; };
+		FEEDBAC000000000000000F6 /* BugSplatFeedbackResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F1 /* BugSplatFeedbackResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEEDBAC000000000000000F7 /* BugSplatFeedbackResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F1 /* BugSplatFeedbackResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEEDBAC000000000000000F8 /* BugSplatFeedbackResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEDBAC000000000000000F1 /* BugSplatFeedbackResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63E233862B9715B50066C7FC /* BugSplat.h in Headers */ = {isa = PBXBuildFile; fileRef = 63C6E1FE2B9283B000AED3E3 /* BugSplat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		73DEAA0D4412D3A9CF562633 /* BugSplatHangPersistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */; };
 		7C235FBB8C978B3EC7E2CE49 /* BugSplatHangPersistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */; };
@@ -117,6 +123,8 @@
 		63D006F92BBF785B00587FBF /* BugSplatMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugSplatMac.h; sourceTree = "<group>"; };
 		63E2337A2B9710410066C7FC /* BugSplatAttachment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugSplatAttachment.m; sourceTree = "<group>"; };
 		63E2337C2B9710420066C7FC /* BugSplatAttachment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugSplatAttachment.h; sourceTree = "<group>"; };
+		FEEDBAC000000000000000F1 /* BugSplatFeedbackResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugSplatFeedbackResult.h; sourceTree = "<group>"; };
+		FEEDBAC000000000000000F2 /* BugSplatFeedbackResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugSplatFeedbackResult.m; sourceTree = "<group>"; };
 		680274C471C325469FD5AB4B /* BugSplatHangPersistenceTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BugSplatHangPersistenceTests.m; sourceTree = "<group>"; };
 		6FDD85DA23C98D5070707CC4 /* BugSplatHangTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BugSplatHangTracker.m; sourceTree = "<group>"; };
 		AA0000042E3FA00000000004 /* BugSplatUploadService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugSplatUploadService.m; sourceTree = "<group>"; };
@@ -206,6 +214,8 @@
 				63D006F92BBF785B00587FBF /* BugSplatMac.h */,
 				63E2337C2B9710420066C7FC /* BugSplatAttachment.h */,
 				63E2337A2B9710410066C7FC /* BugSplatAttachment.m */,
+				FEEDBAC000000000000000F1 /* BugSplatFeedbackResult.h */,
+				FEEDBAC000000000000000F2 /* BugSplatFeedbackResult.m */,
 				6344718C2B9695C500EBEBEB /* BugSplatDelegate.h */,
 				637DF0442D49A49C00DDD8FE /* BugSplatUtilities.h */,
 				637DF0472D49A50800DDD8FE /* BugSplatUtilities.m */,
@@ -303,6 +313,7 @@
 				63D006FA2BBF785B00587FBF /* BugSplatMac.h in Headers */,
 				638D38DD2BA0CEEA00DC37A8 /* BugSplatDelegate.h in Headers */,
 				63E233822B9710420066C7FC /* BugSplatAttachment.h in Headers */,
+				FEEDBAC000000000000000F6 /* BugSplatFeedbackResult.h in Headers */,
 				637DF0452D49A49C00DDD8FE /* BugSplatUtilities.h in Headers */,
 				AA0000062E3FA00000000006 /* BugSplatUploadService.h in Headers */,
 				AA0000112E3FA00000000011 /* BugSplatCrashReportWindow.h in Headers */,
@@ -318,6 +329,7 @@
 				63E233862B9715B50066C7FC /* BugSplat.h in Headers */,
 				638D38DC2BA0CEE900DC37A8 /* BugSplatDelegate.h in Headers */,
 				63E233842B9711AB0066C7FC /* BugSplatAttachment.h in Headers */,
+				FEEDBAC000000000000000F7 /* BugSplatFeedbackResult.h in Headers */,
 				637DF0462D49A49C00DDD8FE /* BugSplatUtilities.h in Headers */,
 				AA0000082E3FA00000000008 /* BugSplatUploadService.h in Headers */,
 				AA0000182E3FA00000000018 /* BugSplatZipHelper.h in Headers */,
@@ -331,6 +343,7 @@
 			files = (
 				BB0000062E3FB00000000006 /* BugSplat.h in Headers */,
 				BB0000072E3FB00000000007 /* BugSplatAttachment.h in Headers */,
+				FEEDBAC000000000000000F8 /* BugSplatFeedbackResult.h in Headers */,
 				BB0000082E3FB00000000008 /* BugSplatDelegate.h in Headers */,
 				BB0000092E3FB00000000009 /* BugSplatUtilities.h in Headers */,
 				BB0000102E3FB00000000010 /* BugSplatUploadService.h in Headers */,
@@ -524,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63E233802B9710420066C7FC /* BugSplatAttachment.m in Sources */,
+				FEEDBAC000000000000000F3 /* BugSplatFeedbackResult.m in Sources */,
 				637DF0482D49A50800DDD8FE /* BugSplatUtilities.m in Sources */,
 				63598C432BA0CCD500770E43 /* BugSplat.m in Sources */,
 				AA0000032E3FA00000000003 /* BugSplatUploadService.m in Sources */,
@@ -538,6 +552,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63E233852B9711B10066C7FC /* BugSplatAttachment.m in Sources */,
+				FEEDBAC000000000000000F4 /* BugSplatFeedbackResult.m in Sources */,
 				637DF0492D49A50800DDD8FE /* BugSplatUtilities.m in Sources */,
 				63598C442BA0CCD500770E43 /* BugSplat.m in Sources */,
 				AA0000052E3FA00000000005 /* BugSplatUploadService.m in Sources */,
@@ -552,6 +567,7 @@
 			files = (
 				BB0000012E3FB00000000001 /* BugSplat.m in Sources */,
 				BB0000022E3FB00000000002 /* BugSplatAttachment.m in Sources */,
+				FEEDBAC000000000000000F5 /* BugSplatFeedbackResult.m in Sources */,
 				BB0000032E3FB00000000003 /* BugSplatUtilities.m in Sources */,
 				BB0000042E3FB00000000004 /* BugSplatUploadService.m in Sources */,
 				BB0000052E3FB00000000005 /* BugSplatZipHelper.m in Sources */,

--- a/BugSplatFeedbackResult.h
+++ b/BugSplatFeedbackResult.h
@@ -1,0 +1,51 @@
+//
+//  BugSplatFeedbackResult.h
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The result of a successful user-feedback submission.
+ *
+ * Returned via the completion handler of
+ * `-postFeedback:description:userName:userEmail:appKey:attributes:attachments:completion:`.
+ * Both properties are populated from the `commitS3CrashUpload` server response and may
+ * be nil if the server response did not include the corresponding value.
+ */
+@interface BugSplatFeedbackResult : NSObject
+
+/**
+ * The BugSplat report id assigned to the submitted feedback.
+ *
+ * Use this to deep-link to the report, e.g.
+ * `https://app.bugsplat.com/v2/crash?database={database}&id={crashId}`.
+ */
+@property (nonatomic, readonly, copy, nullable) NSNumber *crashId;
+
+/**
+ * URL to the report details page returned by the server.
+ *
+ * Note: feedback reports group by their (unique) title, so `infoUrl` may resolve to a
+ * generic page. To link to a specific report, prefer building a URL from `crashId`.
+ */
+@property (nonatomic, readonly, copy, nullable) NSString *infoUrl;
+
+/**
+ * Designated initializer.
+ *
+ * @param crashId The BugSplat report id, or nil if unavailable.
+ * @param infoUrl The report info URL, or nil if unavailable.
+ */
+- (instancetype)initWithCrashId:(nullable NSNumber *)crashId
+                        infoUrl:(nullable NSString *)infoUrl NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugSplatFeedbackResult.m
+++ b/BugSplatFeedbackResult.m
@@ -1,0 +1,27 @@
+//
+//  BugSplatFeedbackResult.m
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import "BugSplatFeedbackResult.h"
+
+@implementation BugSplatFeedbackResult
+
+- (instancetype)initWithCrashId:(NSNumber *)crashId infoUrl:(NSString *)infoUrl
+{
+    if ((self = [super init]))
+    {
+        _crashId = [crashId copy];
+        _infoUrl = [infoUrl copy];
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: crashId=%@, infoUrl=%@>",
+            NSStringFromClass([self class]), self.crashId, self.infoUrl];
+}
+
+@end

--- a/BugSplatFeedbackResult.m
+++ b/BugSplatFeedbackResult.m
@@ -8,7 +8,7 @@
 
 @implementation BugSplatFeedbackResult
 
-- (instancetype)initWithCrashId:(NSNumber *)crashId infoUrl:(NSString *)infoUrl
+- (instancetype)initWithCrashId:(nullable NSNumber *)crashId infoUrl:(nullable NSString *)infoUrl
 {
     if ((self = [super init]))
     {

--- a/BugSplatUploadService.h
+++ b/BugSplatUploadService.h
@@ -6,6 +6,7 @@
 
 #import <Foundation/Foundation.h>
 #import "BugSplatAttachment.h"
+#import "BugSplatFeedbackResult.h"
 #import "BugSplatTestSupport.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -54,8 +55,18 @@ NS_ASSUME_NONNULL_BEGIN
  * @param success YES if the upload was successful.
  * @param error Error object if the upload failed, nil otherwise.
  * @param infoUrl URL to the crash report details page (only provided on success).
+ * @param crashId The BugSplat report id parsed from the commit response
+ *                (only provided on success; may be nil if the server omitted it).
  */
-typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error, NSString * _Nullable infoUrl);
+typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error, NSString * _Nullable infoUrl, NSNumber * _Nullable crashId);
+
+/**
+ * Completion handler for feedback upload operations.
+ *
+ * @param result Non-nil on success, carrying the report id and infoUrl.
+ * @param error Non-nil on failure.
+ */
+typedef void(^BugSplatFeedbackUploadCompletion)(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error);
 
 /**
  * Service for uploading crash reports to BugSplat servers.
@@ -121,7 +132,7 @@ typedef void(^BugSplatUploadCompletion)(BOOL success, NSError * _Nullable error,
            description:(nullable NSString *)description
            attachments:(nullable NSArray<BugSplatAttachment *> *)attachments
               metadata:(BugSplatCrashMetadata *)metadata
-            completion:(void (^)(NSError * _Nullable error))completion;
+            completion:(nullable BugSplatFeedbackUploadCompletion)completion;
 
 /**
  * Cancels any in-progress upload.

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -530,8 +530,16 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                 id rawCrashId = responseJson[@"crashId"];
                 if ([rawCrashId isKindOfClass:[NSNumber class]]) {
                     crashId = rawCrashId;
-                } else if ([rawCrashId isKindOfClass:[NSString class]] && [(NSString *)rawCrashId length] > 0) {
-                    crashId = @([(NSString *)rawCrashId longLongValue]);
+                } else if ([rawCrashId isKindOfClass:[NSString class]]) {
+                    // Only accept a string that is entirely a valid integer —
+                    // -longLongValue would otherwise turn garbage into @0.
+                    NSString *trimmed = [(NSString *)rawCrashId
+                        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+                    NSScanner *scanner = [NSScanner scannerWithString:trimmed];
+                    long long parsed = 0;
+                    if (trimmed.length > 0 && [scanner scanLongLong:&parsed] && scanner.atEnd) {
+                        crashId = @(parsed);
+                    }
                 }
                 if (crashId) {
                     NSLog(@"BugSplat: Crash report id: %@", crashId);

--- a/BugSplatUploadService.m
+++ b/BugSplatUploadService.m
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData
                                              userInfo:@{NSLocalizedDescriptionKey: @"Crash data is empty"}];
-            completion(NO, error, nil);
+            completion(NO, error, nil, nil);
             return;
         }
         
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData
                                              userInfo:@{NSLocalizedDescriptionKey: @"Failed to create ZIP archive"}];
-            completion(NO, error, nil);
+            completion(NO, error, nil, nil);
             return;
         }
         
@@ -131,14 +131,14 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                                     size:zipData.length
                               completion:^(NSString *presignedURL, NSError *error) {
             if (error) {
-                completion(NO, error, nil);
+                completion(NO, error, nil, nil);
                 return;
             }
             
             // Step 2: Upload to S3
             [self uploadData:zipData toPresignedURL:presignedURL completion:^(BOOL success, NSError *uploadError) {
                 if (!success) {
-                    completion(NO, uploadError, nil);
+                    completion(NO, uploadError, nil, nil);
                     return;
                 }
                 
@@ -157,7 +157,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
         NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                              code:BugSplatUploadErrorCodeInvalidData
                                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Exception: %@", exception.reason]}];
-        completion(NO, error, nil);
+        completion(NO, error, nil, nil);
     }
 }
 
@@ -165,10 +165,10 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
            description:(NSString *)description
            attachments:(NSArray<BugSplatAttachment *> *)attachments
               metadata:(BugSplatCrashMetadata *)metadata
-            completion:(void (^)(NSError * _Nullable error))completion
+            completion:(BugSplatFeedbackUploadCompletion)completion
 {
     // Substitute a no-op block so the upload proceeds even without a caller-supplied completion
-    void (^safeCompletion)(NSError * _Nullable) = completion ?: ^(NSError * _Nullable __unused error) {};
+    BugSplatFeedbackUploadCompletion safeCompletion = completion ?: ^(BugSplatFeedbackResult * _Nullable __unused result, NSError * _Nullable __unused error) {};
 
     @try {
         // Validate that title is non-nil and non-empty
@@ -176,7 +176,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData
                                              userInfo:@{NSLocalizedDescriptionKey: @"Feedback title is required and cannot be empty"}];
-            safeCompletion(error);
+            safeCompletion(nil, error);
             return;
         }
 
@@ -190,7 +190,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
         NSError *jsonError;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:feedbackDict options:0 error:&jsonError];
         if (jsonError) {
-            safeCompletion(jsonError);
+            safeCompletion(nil, jsonError);
             return;
         }
 
@@ -216,7 +216,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
             NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                                  code:BugSplatUploadErrorCodeInvalidData
                                              userInfo:@{NSLocalizedDescriptionKey: @"Failed to create feedback ZIP archive"}];
-            safeCompletion(error);
+            safeCompletion(nil, error);
             return;
         }
 
@@ -234,14 +234,14 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                                     size:zipData.length
                               completion:^(NSString *presignedURL, NSError *error) {
             if (error) {
-                safeCompletion(error);
+                safeCompletion(nil, error);
                 return;
             }
 
             // Step 2: Upload to S3
             [self uploadData:zipData toPresignedURL:presignedURL completion:^(BOOL success, NSError *uploadError) {
                 if (!success) {
-                    safeCompletion(uploadError);
+                    safeCompletion(nil, uploadError);
                     return;
                 }
 
@@ -252,12 +252,14 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                             applicationName:appName
                          applicationVersion:appVersion
                                    metadata:metadata
-                                 completion:^(BOOL commitSuccess, NSError *commitError, NSString *infoUrl) {
+                                 completion:^(BOOL commitSuccess, NSError *commitError, NSString *infoUrl, NSNumber *crashId) {
                     if (commitSuccess) {
                         NSLog(@"BugSplat: User feedback uploaded successfully");
-                        safeCompletion(nil);
+                        BugSplatFeedbackResult *result = [[BugSplatFeedbackResult alloc] initWithCrashId:crashId
+                                                                                                 infoUrl:infoUrl];
+                        safeCompletion(result, nil);
                     } else {
-                        safeCompletion(commitError);
+                        safeCompletion(nil, commitError);
                     }
                 }];
             }];
@@ -267,7 +269,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
         NSError *error = [NSError errorWithDomain:BugSplatUploadErrorDomain
                                              code:BugSplatUploadErrorCodeInvalidData
                                          userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Exception: %@", exception.reason]}];
-        safeCompletion(error);
+        safeCompletion(nil, error);
     }
 }
 
@@ -495,7 +497,7 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
     self.currentTask = [self.urlSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                completion(NO, error, nil);
+                completion(NO, error, nil, nil);
             });
             return;
         }
@@ -507,27 +509,39 @@ typedef NS_ENUM(NSInteger, BugSplatUploadErrorCode) {
                                                        code:BugSplatUploadErrorCodeServerError
                                                    userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Commit failed with status %ld: %@", (long)httpResponse.statusCode, responseBody ?: @""]}];
             dispatch_async(dispatch_get_main_queue(), ^{
-                completion(NO, commitError, nil);
+                completion(NO, commitError, nil, nil);
             });
             return;
         }
         
-        // Parse response to extract infoUrl
+        // Parse response to extract infoUrl and the report id (crashId)
         NSString *infoUrl = nil;
+        NSNumber *crashId = nil;
         if (data.length > 0) {
             NSError *jsonError = nil;
             NSDictionary *responseJson = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
             if (!jsonError && [responseJson isKindOfClass:[NSDictionary class]]) {
-                infoUrl = responseJson[@"infoUrl"];
-                if (infoUrl) {
+                id rawInfoUrl = responseJson[@"infoUrl"];
+                if ([rawInfoUrl isKindOfClass:[NSString class]]) {
+                    infoUrl = rawInfoUrl;
                     NSLog(@"BugSplat: Crash report info URL: %@", infoUrl);
+                }
+                // crashId is a JSON integer, but tolerate a string-encoded value too.
+                id rawCrashId = responseJson[@"crashId"];
+                if ([rawCrashId isKindOfClass:[NSNumber class]]) {
+                    crashId = rawCrashId;
+                } else if ([rawCrashId isKindOfClass:[NSString class]] && [(NSString *)rawCrashId length] > 0) {
+                    crashId = @([(NSString *)rawCrashId longLongValue]);
+                }
+                if (crashId) {
+                    NSLog(@"BugSplat: Crash report id: %@", crashId);
                 }
             }
         }
-        
+
         NSLog(@"BugSplat: Crash report uploaded successfully");
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion(YES, nil, infoUrl);
+            completion(YES, nil, infoUrl, crashId);
         });
     }];
     

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		63D006E42BBF4A5500587FBF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D006E32BBF4A5500587FBF /* ContentView.swift */; };
 		63D000AC10010000000000A2 /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC10010000000000A1 /* ActivityLog.swift */; };
 		63D000AC10010000000000D2 /* ShakeNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC10010000000000D1 /* ShakeNotification.swift */; };
+		FEEDBAC010010000000000A1 /* FeedbackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC010010000000000A2 /* FeedbackSheet.swift */; };
 		63D000AC10010000000000B2 /* DemoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC10010000000000B1 /* DemoTheme.swift */; };
 		63D000AC10010000000000C2 /* DemoComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC10010000000000C1 /* DemoComponents.swift */; };
 		63D006E92BBF4A5700587FBF /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63D006E82BBF4A5700587FBF /* Preview Assets.xcassets */; };
@@ -40,6 +41,7 @@
 		63D006E32BBF4A5500587FBF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		63D000AC10010000000000A1 /* ActivityLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLog.swift; sourceTree = "<group>"; };
 		63D000AC10010000000000D1 /* ShakeNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeNotification.swift; sourceTree = "<group>"; };
+		FEEDBAC010010000000000A2 /* FeedbackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSheet.swift; sourceTree = "<group>"; };
 		63D000AC10010000000000B1 /* DemoTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTheme.swift; sourceTree = "<group>"; };
 		63D000AC10010000000000C1 /* DemoComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoComponents.swift; sourceTree = "<group>"; };
 		63D006E82BBF4A5700587FBF /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -66,6 +68,7 @@
 				63D006E32BBF4A5500587FBF /* ContentView.swift */,
 				63D000AC10010000000000A1 /* ActivityLog.swift */,
 				63D000AC10010000000000D1 /* ShakeNotification.swift */,
+				FEEDBAC010010000000000A2 /* FeedbackSheet.swift */,
 				63D000AC10010000000000B1 /* DemoTheme.swift */,
 				63D000AC10010000000000C1 /* DemoComponents.swift */,
 				63D006E72BBF4A5700587FBF /* Preview Content */,
@@ -207,6 +210,7 @@
 				63D006E42BBF4A5500587FBF /* ContentView.swift in Sources */,
 				63D000AC10010000000000A2 /* ActivityLog.swift in Sources */,
 				63D000AC10010000000000D2 /* ShakeNotification.swift in Sources */,
+				FEEDBAC010010000000000A1 /* FeedbackSheet.swift in Sources */,
 				63D000AC10010000000000B2 /* DemoTheme.swift in Sources */,
 				63D000AC10010000000000C2 /* DemoComponents.swift in Sources */,
 				63D006E22BBF4A5500587FBF /* BugSplatTest-SwiftUIApp.swift in Sources */,

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/ContentView.swift
@@ -13,9 +13,6 @@ struct ContentView: View {
     @State private var entries: [ActivityEntry] = ActivityLog.all()
     @State private var showFeedbackSheet = false
     @State private var showHangConfirm = false
-    @State private var feedbackTitle = ""
-    @State private var feedbackDescription = ""
-    @State private var feedbackStatus: String?
     @Environment(\.scenePhase) private var scenePhase
 
     private var database: String {
@@ -61,7 +58,7 @@ struct ContentView: View {
 
                 recentActivityCard.padding(.top, 18)
 
-                Text(feedbackStatus ?? "Shake the device to send feedback anytime.")
+                Text("Shake the device to send feedback anytime.")
                     .font(.system(size: 13))
                     .foregroundColor(DemoColor.textTertiary)
                     .frame(maxWidth: .infinity)
@@ -78,11 +75,8 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active { entries = ActivityLog.all() }
         }
-        .alert("Send Feedback", isPresented: $showFeedbackSheet) {
-            TextField("Title", text: $feedbackTitle)
-            TextField("Description", text: $feedbackDescription)
-            Button("Send") { sendFeedback() }
-            Button("Cancel", role: .cancel) { }
+        .sheet(isPresented: $showFeedbackSheet, onDismiss: { entries = ActivityLog.all() }) {
+            FeedbackSheet()
         }
         .alert("Simulate Fatal Hang?", isPresented: $showHangConfirm) {
             Button("Hang App", role: .destructive) { simulateHang() }
@@ -185,37 +179,6 @@ struct ContentView: View {
         // Single sleep until distantFuture (~year 4001) - simpler than a spin
         // loop and keeps the CPU quiet while frozen.
         Thread.sleep(until: .distantFuture)
-    }
-
-    private func sendFeedback() {
-        let title = feedbackTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Treat an empty title the same as Cancel - don't submit, don't record.
-        guard !title.isEmpty else {
-            feedbackTitle = ""
-            feedbackDescription = ""
-            return
-        }
-        feedbackStatus = "Sending..."
-        BugSplat.shared().postFeedback(
-            title: title,
-            description: feedbackDescription.isEmpty ? nil : feedbackDescription,
-            userName: nil,
-            userEmail: nil,
-            appKey: nil,
-            attachments: nil
-        ) { error in
-            DispatchQueue.main.async {
-                if let error {
-                    feedbackStatus = "Feedback failed: \(error.localizedDescription)"
-                } else {
-                    feedbackStatus = "Feedback sent — thank you!"
-                    ActivityLog.record(.feedback, detail: "\u{201C}\(title)\u{201D}")
-                    entries = ActivityLog.all()
-                    feedbackTitle = ""
-                    feedbackDescription = ""
-                }
-            }
-        }
     }
 
     private func openDashboard() {

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/DemoTheme.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/DemoTheme.swift
@@ -21,6 +21,11 @@ enum DemoColor {
     static let pillStroke   = Color(hex: 0xE4E2DA)
     static let connectedDot = Color(hex: 0x22C55E)
     static let link         = Color(hex: 0x1F73E8)
+    // Primary action green used by the feedback sheet (form + thank-you buttons).
+    static let feedbackAccent = Color(hex: 0x4E9D78)
+    static let fieldBg      = Color(hex: 0xFFFFFF)
+    static let footerBg     = Color(hex: 0xF4F2EA)
+    static let asterisk     = Color(hex: 0xDC2626)
 
     static let activityCrash    = Color(hex: 0x1F73E8)
     static let activityError    = Color(hex: 0xE5B142)

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/FeedbackSheet.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/FeedbackSheet.swift
@@ -269,9 +269,6 @@ struct FeedbackSheet: View {
 
     private var footer: some View {
         VStack(spacing: 12) {
-            Text("Triggered by shaking the device.")
-                .font(.system(size: 13))
-                .foregroundColor(DemoColor.textTertiary)
             Button(action: submit) {
                 HStack(spacing: 8) {
                     if isSubmitting {
@@ -296,7 +293,7 @@ struct FeedbackSheet: View {
             .disabled(!canSubmit)
         }
         .padding(.horizontal, 20)
-        .padding(.top, 14)
+        .padding(.top, 20)
         .padding(.bottom, 20)
         .frame(maxWidth: .infinity)
         .background(DemoColor.footerBg.ignoresSafeArea(edges: .bottom))

--- a/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/FeedbackSheet.swift
+++ b/Example_Apps/BugSplatTest-SwiftUI/BugSplatTest-SwiftUI/FeedbackSheet.swift
@@ -1,0 +1,557 @@
+//
+//  FeedbackSheet.swift
+//  BugSplatTest-SwiftUI
+//
+//  The redesigned User Feedback experience: a bottom-sheet form for composing
+//  feedback, and a thank-you confirmation shown in the same sheet after a
+//  successful submit. Mirrors the bugsplat-android demo refresh.
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+import BugSplat
+
+// MARK: - Category
+
+/// Feedback category shown in the segmented selector. The raw value is sent to
+/// BugSplat as the `category` custom attribute.
+enum FeedbackCategory: String, CaseIterable, Identifiable {
+    case bug = "Bug"
+    case feature = "Feature"
+    case other = "Other"
+
+    var id: String { rawValue }
+}
+
+// MARK: - Sample log helper
+
+/// Locates the `sample_log.txt` file the app writes at launch (see
+/// `BugSplatInitializer`) so it can be attached to feedback when the user opts in.
+enum SampleLog {
+    static var fileURL: URL? {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("sample_log.txt")
+    }
+
+    /// Returns the sample log as a `BugSplatAttachment`, or nil if it cannot be read.
+    static func attachment() -> BugSplatAttachment? {
+        guard let url = fileURL, let data = try? Data(contentsOf: url) else { return nil }
+        return BugSplatAttachment(filename: "sample_log.txt",
+                                  attachmentData: data,
+                                  contentType: "text/plain")
+    }
+}
+
+// MARK: - Picked attachment
+
+/// A user-chosen file selected via the document picker.
+struct PickedAttachment {
+    let name: String
+    let data: Data
+
+    var sizeText: String {
+        ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)
+    }
+
+    var typeChip: String {
+        let ext = (name as NSString).pathExtension.uppercased()
+        return ext.isEmpty ? "FILE" : ext
+    }
+
+    func bugSplatAttachment() -> BugSplatAttachment {
+        let type = UTType(filenameExtension: (name as NSString).pathExtension)
+        let mime = type?.preferredMIMEType ?? "application/octet-stream"
+        return BugSplatAttachment(filename: name, attachmentData: data, contentType: mime)
+    }
+}
+
+// MARK: - Feedback sheet
+
+struct FeedbackSheet: View {
+    /// Which screen the sheet is currently showing.
+    private enum Phase {
+        case form
+        case thanks(BugSplatFeedbackResult?)
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    @State private var phase: Phase = .form
+
+    // Form state — preserved across a failed submit so the user loses nothing.
+    @State private var category: FeedbackCategory = .bug
+    @State private var title = ""
+    @State private var feedbackDescription = ""
+    @State private var name = ""
+    @State private var email = ""
+    @State private var includeLogs = true
+    @State private var pickedFile: PickedAttachment?
+
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+    @State private var showFileImporter = false
+
+    private var database: String {
+        BugSplat.shared().bugSplatDatabase ?? "—"
+    }
+
+    private var canSubmit: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSubmitting
+    }
+
+    var body: some View {
+        Group {
+            switch phase {
+            case .form:
+                formScreen
+            case .thanks(let result):
+                FeedbackThanksView(result: result, database: database) {
+                    dismiss()
+                }
+            }
+        }
+        .background(DemoColor.cardBg.ignoresSafeArea())
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: Form screen
+
+    private var formScreen: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(DemoColor.cardStroke)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    categoryPicker
+                    field(label: "Title", required: true) {
+                        TextField("", text: $title)
+                            .textFieldStyle(.plain)
+                            .modifier(FieldBox())
+                    }
+                    field(label: "Description", required: false) {
+                        TextField("", text: $feedbackDescription, axis: .vertical)
+                            .textFieldStyle(.plain)
+                            .lineLimit(3...6)
+                            .modifier(FieldBox())
+                    }
+                    field(label: "Name", required: false) {
+                        TextField("", text: $name)
+                            .textFieldStyle(.plain)
+                            .textContentType(.name)
+                            .modifier(FieldBox())
+                    }
+                    field(label: "Email", required: false) {
+                        TextField("", text: $email)
+                            .textFieldStyle(.plain)
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .modifier(FieldBox())
+                    }
+                    field(label: "Attachment", required: false) {
+                        attachmentRow
+                    }
+                    includeLogsRow
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 13))
+                            .foregroundColor(DemoColor.asterisk)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(20)
+            }
+
+            footer
+        }
+        .fileImporter(isPresented: $showFileImporter,
+                      allowedContentTypes: [.item],
+                      allowsMultipleSelection: false) { result in
+            handleFileImport(result)
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Send feedback")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(DemoColor.textPrimary)
+            Spacer()
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(DemoColor.textSecondary)
+            }
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+    }
+
+    private var categoryPicker: some View {
+        Picker("Category", selection: $category) {
+            ForEach(FeedbackCategory.allCases) { category in
+                Text(category.rawValue).tag(category)
+            }
+        }
+        .pickerStyle(.segmented)
+        .disabled(isSubmitting)
+    }
+
+    private var attachmentRow: some View {
+        Group {
+            if let pickedFile {
+                HStack(spacing: 12) {
+                    Text(pickedFile.typeChip)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(DemoColor.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(DemoColor.badgeBg))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(pickedFile.name)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(DemoColor.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(pickedFile.sizeText)
+                            .font(.system(size: 12))
+                            .foregroundColor(DemoColor.textTertiary)
+                    }
+                    Spacer(minLength: 8)
+                    Button("Replace") { showFileImporter = true }
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(DemoColor.link)
+                        .disabled(isSubmitting)
+                }
+                .padding(12)
+                .modifier(OutlinedCard())
+            } else {
+                Button(action: { showFileImporter = true }) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "paperclip")
+                            .font(.system(size: 15, weight: .semibold))
+                        Text("Add attachment")
+                            .font(.system(size: 14, weight: .semibold))
+                        Spacer()
+                    }
+                    .foregroundColor(DemoColor.link)
+                    .padding(12)
+                    .modifier(OutlinedCard())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSubmitting)
+            }
+        }
+    }
+
+    private var includeLogsRow: some View {
+        Toggle(isOn: $includeLogs) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Include logs")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(DemoColor.textPrimary)
+                Text("Attach the app's sample_log.txt")
+                    .font(.system(size: 12))
+                    .foregroundColor(DemoColor.textTertiary)
+            }
+        }
+        .tint(DemoColor.feedbackAccent)
+        .disabled(isSubmitting)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 12) {
+            Text("Triggered by shaking the device.")
+                .font(.system(size: 13))
+                .foregroundColor(DemoColor.textTertiary)
+            Button(action: submit) {
+                HStack(spacing: 8) {
+                    if isSubmitting {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .tint(.white)
+                    } else {
+                        Text("Send feedback")
+                            .font(.system(size: 17, weight: .bold))
+                        Image(systemName: "arrow.right")
+                            .font(.system(size: 15, weight: .bold))
+                    }
+                }
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity, minHeight: 52)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(canSubmit ? DemoColor.feedbackAccent : DemoColor.feedbackAccent.opacity(0.4))
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSubmit)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 14)
+        .padding(.bottom, 20)
+        .frame(maxWidth: .infinity)
+        .background(DemoColor.footerBg.ignoresSafeArea(edges: .bottom))
+        .overlay(Divider().overlay(DemoColor.cardStroke), alignment: .top)
+    }
+
+    // MARK: Field helper
+
+    @ViewBuilder
+    private func field<Content: View>(label: String,
+                                      required: Bool,
+                                      @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 2) {
+                Text(label)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(DemoColor.textPrimary)
+                if required {
+                    Text("*").font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(DemoColor.asterisk)
+                }
+                Spacer()
+                if !required {
+                    Text("optional")
+                        .font(.system(size: 13))
+                        .foregroundColor(DemoColor.textTertiary)
+                }
+            }
+            content()
+        }
+    }
+
+    // MARK: Actions
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let data = try Data(contentsOf: url)
+                pickedFile = PickedAttachment(name: url.lastPathComponent, data: data)
+            } catch {
+                errorMessage = "Couldn't read the selected file: \(error.localizedDescription)"
+            }
+        case .failure(let error):
+            errorMessage = "File selection failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func submit() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+
+        isSubmitting = true
+        errorMessage = nil
+
+        var attachments: [BugSplatAttachment] = []
+        if let pickedFile { attachments.append(pickedFile.bugSplatAttachment()) }
+        if includeLogs, let logAttachment = SampleLog.attachment() {
+            attachments.append(logAttachment)
+        }
+
+        BugSplat.shared().postFeedback(
+            title: trimmedTitle,
+            description: feedbackDescription.isEmpty ? nil : feedbackDescription,
+            userName: name.isEmpty ? nil : name,
+            userEmail: email.isEmpty ? nil : email,
+            appKey: nil,
+            attributes: ["category": category.rawValue],
+            attachments: attachments.isEmpty ? nil : attachments
+        ) { result, error in
+            DispatchQueue.main.async {
+                isSubmitting = false
+                if let error {
+                    errorMessage = "Feedback failed: \(error.localizedDescription)"
+                } else {
+                    ActivityLog.record(.feedback, detail: "\u{201C}\(trimmedTitle)\u{201D}")
+                    withAnimation { phase = .thanks(result) }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Thank-you view
+
+struct FeedbackThanksView: View {
+    let result: BugSplatFeedbackResult?
+    let database: String
+    let onClose: () -> Void
+
+    @Environment(\.openURL) private var openURL
+
+    private var reportId: String? {
+        result?.crashId.map { "\($0)" }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 24)
+
+            VStack(spacing: 18) {
+                ZStack {
+                    Circle()
+                        .fill(DemoColor.feedbackAccent.opacity(0.14))
+                        .frame(width: 84, height: 84)
+                    Circle()
+                        .stroke(DemoColor.feedbackAccent.opacity(0.35), lineWidth: 1)
+                        .frame(width: 84, height: 84)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 34, weight: .bold))
+                        .foregroundColor(DemoColor.feedbackAccent)
+                }
+
+                VStack(spacing: 8) {
+                    Text("Feedback sent. Thanks!")
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(DemoColor.textPrimary)
+                    Text("Your note made it to the BugSplat team. We reply within a day.")
+                        .font(.system(size: 15))
+                        .foregroundColor(DemoColor.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 24)
+
+                reportIdRow
+            }
+
+            Spacer(minLength: 24)
+
+            VStack(spacing: 14) {
+                Button(action: openDashboard) {
+                    HStack(spacing: 8) {
+                        Text("View on dashboard")
+                            .font(.system(size: 17, weight: .bold))
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 14, weight: .bold))
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, minHeight: 52)
+                    .background(RoundedRectangle(cornerRadius: 12).fill(DemoColor.feedbackAccent))
+                }
+                .buttonStyle(.plain)
+
+                Button("Close", action: onClose)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(DemoColor.textSecondary)
+
+                poweredByFooter
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 14)
+            .padding(.bottom, 20)
+            .frame(maxWidth: .infinity)
+            .background(DemoColor.footerBg.ignoresSafeArea(edges: .bottom))
+            .overlay(Divider().overlay(DemoColor.cardStroke), alignment: .top)
+        }
+    }
+
+    private var reportIdRow: some View {
+        HStack(spacing: 12) {
+            Text("REPORT ID")
+                .font(.system(size: 11, weight: .semibold))
+                .tracking(1.1)
+                .foregroundColor(DemoColor.textTertiary)
+            Text(reportId ?? "Unavailable")
+                .font(.system(size: 15, weight: .medium, design: .monospaced))
+                .foregroundColor(DemoColor.textPrimary)
+            Spacer(minLength: 8)
+            if let reportId {
+                Button(action: { UIPasteboard.general.string = reportId }) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text("Copy").font(.system(size: 13, weight: .semibold))
+                    }
+                    .foregroundColor(DemoColor.textSecondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8).fill(DemoColor.cardBg)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8).stroke(DemoColor.cardStroke, lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(RoundedRectangle(cornerRadius: 12).fill(DemoColor.badgeBg))
+        .padding(.horizontal, 20)
+    }
+
+    private var poweredByFooter: some View {
+        HStack(spacing: 4) {
+            Text("Powered by")
+                .font(.system(size: 13))
+                .foregroundColor(DemoColor.textTertiary)
+            Link("BugSplat", destination: URL(string: "https://bugsplat.com")!)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(DemoColor.link)
+        }
+        .padding(.top, 2)
+    }
+
+    /// Links directly to the report by id. Feedback reports group by their
+    /// (unique) title, so the SDK's infoUrl resolves to a generic page — prefer
+    /// the id-scoped crash URL, falling back to the database dashboard.
+    private func openDashboard() {
+        var components: URLComponents?
+        if let crashId = result?.crashId {
+            components = URLComponents(string: "https://app.bugsplat.com/v2/crash")
+            components?.queryItems = [
+                URLQueryItem(name: "database", value: database),
+                URLQueryItem(name: "id", value: "\(crashId)")
+            ]
+        } else {
+            components = URLComponents(string: "https://app.bugsplat.com/v2/dashboard")
+            components?.queryItems = [URLQueryItem(name: "database", value: database)]
+        }
+        if let url = components?.url {
+            openURL(url)
+        }
+    }
+}
+
+// MARK: - Styling helpers
+
+/// Rounded, outlined container used for text fields.
+private struct FieldBox: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 15))
+            .foregroundColor(DemoColor.textPrimary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 11)
+            .background(RoundedRectangle(cornerRadius: 10).fill(DemoColor.fieldBg))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(DemoColor.cardStroke, lineWidth: 1))
+    }
+}
+
+/// Rounded, outlined container used for the attachment row.
+private struct OutlinedCard: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity)
+            .background(RoundedRectangle(cornerRadius: 10).fill(DemoColor.fieldBg))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(DemoColor.cardStroke, lineWidth: 1))
+    }
+}
+
+#Preview {
+    FeedbackSheet()
+}

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		63D000AC20010000000000A2 /* BSPActivityLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC20010000000000A1 /* BSPActivityLog.m */; };
 		63D000AC20010000000000B2 /* BSPDemoTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC20010000000000B1 /* BSPDemoTheme.m */; };
 		63D000AC20010000000000C2 /* BSPDemoViews.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D000AC20010000000000C1 /* BSPDemoViews.m */; };
+		FEEDBAC030010000000000C2 /* BSPFeedbackViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC030010000000000C1 /* BSPFeedbackViewController.m */; };
 		6341B2532BDC3CA2007EE8AC /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6341B2522BDC3CA2007EE8AC /* Base */; };
 		6341B2552BDC3CA5007EE8AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6341B2542BDC3CA5007EE8AC /* Assets.xcassets */; };
 		6341B2582BDC3CA5007EE8AC /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6341B2572BDC3CA5007EE8AC /* Base */; };
@@ -49,6 +50,8 @@
 		63D000AC20010000000000B1 /* BSPDemoTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPDemoTheme.m; sourceTree = "<group>"; };
 		63D000AC20010000000000C0 /* BSPDemoViews.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSPDemoViews.h; sourceTree = "<group>"; };
 		63D000AC20010000000000C1 /* BSPDemoViews.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPDemoViews.m; sourceTree = "<group>"; };
+		FEEDBAC030010000000000C0 /* BSPFeedbackViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSPFeedbackViewController.h; sourceTree = "<group>"; };
+		FEEDBAC030010000000000C1 /* BSPFeedbackViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPFeedbackViewController.m; sourceTree = "<group>"; };
 		6341B2522BDC3CA2007EE8AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		6341B2542BDC3CA5007EE8AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6341B2572BDC3CA5007EE8AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -101,6 +104,8 @@
 				63D000AC20010000000000B1 /* BSPDemoTheme.m */,
 				63D000AC20010000000000C0 /* BSPDemoViews.h */,
 				63D000AC20010000000000C1 /* BSPDemoViews.m */,
+				FEEDBAC030010000000000C0 /* BSPFeedbackViewController.h */,
+				FEEDBAC030010000000000C1 /* BSPFeedbackViewController.m */,
 				6341B2512BDC3CA2007EE8AC /* Main.storyboard */,
 				6341B2542BDC3CA5007EE8AC /* Assets.xcassets */,
 				6341B2562BDC3CA5007EE8AC /* LaunchScreen.storyboard */,
@@ -219,6 +224,7 @@
 				63D000AC20010000000000A2 /* BSPActivityLog.m in Sources */,
 				63D000AC20010000000000B2 /* BSPDemoTheme.m in Sources */,
 				63D000AC20010000000000C2 /* BSPDemoViews.m in Sources */,
+				FEEDBAC030010000000000C2 /* BSPFeedbackViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPDemoTheme.h
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPDemoTheme.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *)activityFeedback;
 + (UIColor *)activityHang;
 
+/// Primary action green used by the feedback sheet (form + thank-you buttons).
++ (UIColor *)feedbackAccent;
++ (UIColor *)footerBg;
++ (UIColor *)asterisk;
+
 /// Build a UIColor from a packed 0xRRGGBB integer.
 + (UIColor *)colorWithHex:(uint32_t)hex;
 

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPDemoTheme.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPDemoTheme.m
@@ -35,4 +35,8 @@
 + (UIColor *)activityFeedback { return [self colorWithHex:0x22C55E]; }
 + (UIColor *)activityHang     { return [self colorWithHex:0xE5B142]; }
 
++ (UIColor *)feedbackAccent   { return [self colorWithHex:0x4E9D78]; }
++ (UIColor *)footerBg         { return [self colorWithHex:0xF4F2EA]; }
++ (UIColor *)asterisk         { return [self colorWithHex:0xDC2626]; }
+
 @end

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.h
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.h
@@ -1,0 +1,25 @@
+//
+//  BSPFeedbackViewController.h
+//  BugSplatTest-UIKit-ObjC
+//
+//  The redesigned User Feedback experience: a bottom-sheet form for composing
+//  feedback, and a thank-you confirmation shown in the same sheet after a
+//  successful submit. Mirrors the bugsplat-android demo refresh.
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Modal feedback sheet presented from the demo screen.
+@interface BSPFeedbackViewController : UIViewController
+
+/// Called after the sheet is dismissed so the presenter can refresh state
+/// (a page-sheet dismissal does not trigger the presenter's viewWillAppear).
+@property (nonatomic, copy, nullable) void (^onDismiss)(void);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
@@ -70,6 +70,10 @@
 @property (nonatomic, strong, nullable) NSData *pickedFileData;
 @property (nonatomic, assign) BOOL submitting;
 
+// Keyboard handling
+@property (nonatomic, strong) UIScrollView *formScrollView;
+@property (nonatomic, strong) NSLayoutConstraint *layoutBottomConstraint;
+
 @end
 
 @implementation BSPFeedbackViewController
@@ -94,6 +98,7 @@
     [self buildThanksContainer];
     [self renderAttachmentRow];
     [self updateSendEnabled];
+    [self installKeyboardHandling];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -121,6 +126,7 @@
     UIScrollView *scrollView = [UIScrollView new];
     scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+    self.formScrollView = scrollView;
 
     UIStackView *fields = [UIStackView new];
     fields.translatesAutoresizingMaskIntoConstraints = NO;
@@ -174,11 +180,15 @@
     layout.alignment = UIStackViewAlignmentFill;
     [self.formContainer addSubview:layout];
 
+    // Held onto so the keyboard handler can lift the whole layout (scroll view
+    // + footer) above the keyboard.
+    self.layoutBottomConstraint = [layout.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor];
+
     [NSLayoutConstraint activateConstraints:@[
         [layout.topAnchor constraintEqualToAnchor:self.formContainer.safeAreaLayoutGuide.topAnchor],
         [layout.leadingAnchor constraintEqualToAnchor:self.formContainer.leadingAnchor],
         [layout.trailingAnchor constraintEqualToAnchor:self.formContainer.trailingAnchor],
-        [layout.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor],
+        self.layoutBottomConstraint,
 
         [fields.topAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.topAnchor constant:20],
         [fields.bottomAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.bottomAnchor constant:-20],
@@ -465,6 +475,58 @@
     divider.backgroundColor = [BSPDemoTheme cardStroke];
     [divider.heightAnchor constraintEqualToConstant:1].active = YES;
     return divider;
+}
+
+#pragma mark - Keyboard handling
+
+/// Lifts the form (footer + scroll view) above the keyboard and lets a tap
+/// outside any field dismiss it.
+- (void)installKeyboardHandling {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardFrameWillChange:)
+                                                 name:UIKeyboardWillChangeFrameNotification
+                                               object:nil];
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
+        initWithTarget:self action:@selector(dismissKeyboard)];
+    tap.cancelsTouchesInView = NO;  // let buttons/controls still receive the tap
+    [self.view addGestureRecognizer:tap];
+}
+
+- (void)dismissKeyboard {
+    [self.view endEditing:YES];
+}
+
+- (void)keyboardFrameWillChange:(NSNotification *)note {
+    NSDictionary *info = note.userInfo;
+    CGRect endFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    NSTimeInterval duration = [info[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    UIViewAnimationCurve curve = (UIViewAnimationCurve)[info[UIKeyboardAnimationCurveUserInfoKey] integerValue];
+
+    CGRect endInView = [self.view convertRect:endFrame fromView:nil];
+    CGFloat overlap = MAX(0.0, CGRectGetMaxY(self.view.bounds) - CGRectGetMinY(endInView));
+    self.layoutBottomConstraint.constant = -overlap;
+
+    [UIView animateWithDuration:duration
+                          delay:0
+                        options:(UIViewAnimationOptions)(curve << 16)
+                     animations:^{ [self.view layoutIfNeeded]; }
+                     completion:^(BOOL finished) { [self scrollActiveFieldToVisible]; }];
+}
+
+/// Keeps the focused field visible after the scroll view shrinks for the keyboard.
+- (void)scrollActiveFieldToVisible {
+    UIView *active = nil;
+    for (UIView *field in @[ self.titleField, self.descriptionView, self.nameField, self.emailField ]) {
+        if (field.isFirstResponder) { active = field; break; }
+    }
+    if (!active) return;
+    CGRect rect = [self.formScrollView convertRect:active.bounds fromView:active];
+    [self.formScrollView scrollRectToVisible:CGRectInset(rect, 0, -16) animated:YES];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark - Form actions

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
@@ -103,7 +103,9 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    if (self.onDismiss) self.onDismiss();
+    // Only when the sheet is actually going away - not when it is merely
+    // covered by a controller it presented (e.g. the document picker).
+    if (self.isBeingDismissed && self.onDismiss) self.onDismiss();
 }
 
 #pragma mark - Form layout

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
@@ -1,0 +1,819 @@
+//
+//  BSPFeedbackViewController.m
+//  BugSplatTest-UIKit-ObjC
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import "BSPFeedbackViewController.h"
+#import "BSPDemoTheme.h"
+#import "BSPActivityLog.h"
+#import <BugSplat/BugSplat.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+#pragma mark - Sample log helper
+
+/// Locates the `sample_log.txt` file the app writes at launch (see AppDelegate)
+/// so it can be attached to feedback when the user opts in.
+@interface BSPSampleLog : NSObject
++ (nullable NSURL *)fileURL;
++ (nullable BugSplatAttachment *)attachment;
+@end
+
+@implementation BSPSampleLog
+
++ (NSURL *)fileURL {
+    NSURL *docs = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                          inDomains:NSUserDomainMask] firstObject];
+    return [docs URLByAppendingPathComponent:@"sample_log.txt"];
+}
+
++ (BugSplatAttachment *)attachment {
+    NSURL *url = [self fileURL];
+    NSData *data = url ? [NSData dataWithContentsOfURL:url] : nil;
+    if (!data) return nil;
+    return [[BugSplatAttachment alloc] initWithFilename:@"sample_log.txt"
+                                         attachmentData:data
+                                            contentType:@"text/plain"];
+}
+
+@end
+
+#pragma mark - Feedback view controller
+
+@interface BSPFeedbackViewController () <UIDocumentPickerDelegate, UITextFieldDelegate>
+
+// Containers
+@property (nonatomic, strong) UIView *formContainer;
+@property (nonatomic, strong) UIView *thanksContainer;
+
+// Form controls
+@property (nonatomic, strong) UISegmentedControl *segmented;
+@property (nonatomic, strong) UITextField *titleField;
+@property (nonatomic, strong) UITextView *descriptionView;
+@property (nonatomic, strong) UITextField *nameField;
+@property (nonatomic, strong) UITextField *emailField;
+@property (nonatomic, strong) UISwitch *includeLogsSwitch;
+@property (nonatomic, strong) UILabel *errorLabel;
+@property (nonatomic, strong) UIButton *sendButton;
+@property (nonatomic, strong) UIActivityIndicatorView *sendSpinner;
+
+// Attachment row
+@property (nonatomic, strong) UIView *attachmentRow;
+@property (nonatomic, strong) UILabel *attachmentTypeChip;
+@property (nonatomic, strong) UILabel *attachmentNameLabel;
+@property (nonatomic, strong) UILabel *attachmentDetailLabel;
+@property (nonatomic, strong) UIButton *attachmentActionButton;
+
+// State
+@property (nonatomic, copy, nullable) NSString *pickedFileName;
+@property (nonatomic, strong, nullable) NSData *pickedFileData;
+@property (nonatomic, assign) BOOL submitting;
+
+@end
+
+@implementation BSPFeedbackViewController
+
+- (NSString *)database {
+    return [BugSplat shared].bugSplatDatabase ?: @"—";
+}
+
+- (NSString *)selectedCategory {
+    NSArray<NSString *> *categories = @[ @"Bug", @"Feature", @"Other" ];
+    NSInteger index = self.segmented.selectedSegmentIndex;
+    if (index < 0 || index >= (NSInteger)categories.count) return @"Bug";
+    return categories[index];
+}
+
+#pragma mark - Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [BSPDemoTheme cardBg];
+    [self buildForm];
+    [self buildThanksContainer];
+    [self renderAttachmentRow];
+    [self updateSendEnabled];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    if (self.onDismiss) self.onDismiss();
+}
+
+#pragma mark - Form layout
+
+- (void)buildForm {
+    self.formContainer = [UIView new];
+    self.formContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.formContainer];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.formContainer.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.formContainer.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.formContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.formContainer.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    ]];
+
+    UIView *header = [self makeHeaderWithTitle:@"Send feedback"];
+    UIView *headerDivider = [self makeDivider];
+    UIView *footer = [self makeFormFooter];
+
+    UIScrollView *scrollView = [UIScrollView new];
+    scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+    scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+
+    UIStackView *fields = [UIStackView new];
+    fields.translatesAutoresizingMaskIntoConstraints = NO;
+    fields.axis = UILayoutConstraintAxisVertical;
+    fields.spacing = 18;
+    fields.alignment = UIStackViewAlignmentFill;
+
+    self.segmented = [[UISegmentedControl alloc] initWithItems:@[ @"Bug", @"Feature", @"Other" ]];
+    self.segmented.selectedSegmentIndex = 0;
+    [fields addArrangedSubview:self.segmented];
+
+    self.titleField = [self makeTextField];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Title" required:YES input:[self boxedInput:self.titleField]]];
+
+    self.descriptionView = [UITextView new];
+    self.descriptionView.font = [UIFont systemFontOfSize:15];
+    self.descriptionView.textColor = [BSPDemoTheme textPrimary];
+    self.descriptionView.backgroundColor = UIColor.clearColor;
+    self.descriptionView.scrollEnabled = NO;
+    self.descriptionView.textContainerInset = UIEdgeInsetsMake(7, 8, 7, 8);
+    [self.descriptionView.heightAnchor constraintGreaterThanOrEqualToConstant:92].active = YES;
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Description" required:NO input:[self boxedInput:self.descriptionView]]];
+
+    self.nameField = [self makeTextField];
+    self.nameField.textContentType = UITextContentTypeName;
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Name" required:NO input:[self boxedInput:self.nameField]]];
+
+    self.emailField = [self makeTextField];
+    self.emailField.textContentType = UITextContentTypeEmailAddress;
+    self.emailField.keyboardType = UIKeyboardTypeEmailAddress;
+    self.emailField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Email" required:NO input:[self boxedInput:self.emailField]]];
+
+    [self buildAttachmentRow];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Attachment" required:NO input:self.attachmentRow]];
+
+    [fields addArrangedSubview:[self makeIncludeLogsRow]];
+
+    self.errorLabel = [UILabel new];
+    self.errorLabel.font = [UIFont systemFontOfSize:13];
+    self.errorLabel.textColor = [BSPDemoTheme asterisk];
+    self.errorLabel.numberOfLines = 0;
+    self.errorLabel.hidden = YES;
+    [fields addArrangedSubview:self.errorLabel];
+
+    [scrollView addSubview:fields];
+
+    UIStackView *layout = [[UIStackView alloc] initWithArrangedSubviews:@[ header, headerDivider, scrollView, footer ]];
+    layout.translatesAutoresizingMaskIntoConstraints = NO;
+    layout.axis = UILayoutConstraintAxisVertical;
+    layout.alignment = UIStackViewAlignmentFill;
+    [self.formContainer addSubview:layout];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [layout.topAnchor constraintEqualToAnchor:self.formContainer.safeAreaLayoutGuide.topAnchor],
+        [layout.leadingAnchor constraintEqualToAnchor:self.formContainer.leadingAnchor],
+        [layout.trailingAnchor constraintEqualToAnchor:self.formContainer.trailingAnchor],
+        [layout.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor],
+
+        [fields.topAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.topAnchor constant:20],
+        [fields.bottomAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.bottomAnchor constant:-20],
+        [fields.leadingAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.leadingAnchor constant:20],
+        [fields.trailingAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.trailingAnchor constant:-20],
+        [fields.widthAnchor constraintEqualToAnchor:scrollView.frameLayoutGuide.widthAnchor constant:-40],
+    ]];
+}
+
+- (UIView *)makeHeaderWithTitle:(NSString *)title {
+    UILabel *label = [UILabel new];
+    label.text = title;
+    label.font = [UIFont systemFontOfSize:22 weight:UIFontWeightBold];
+    label.textColor = [BSPDemoTheme textPrimary];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UIButton *close = [UIButton buttonWithType:UIButtonTypeSystem];
+    close.translatesAutoresizingMaskIntoConstraints = NO;
+    [close setImage:[UIImage systemImageNamed:@"xmark"] forState:UIControlStateNormal];
+    close.tintColor = [BSPDemoTheme textSecondary];
+    [close addTarget:self action:@selector(closeTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    UIView *bar = [UIView new];
+    bar.translatesAutoresizingMaskIntoConstraints = NO;
+    [bar addSubview:label];
+    [bar addSubview:close];
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:bar.leadingAnchor constant:20],
+        [label.centerYAnchor constraintEqualToAnchor:bar.centerYAnchor],
+        [label.topAnchor constraintEqualToAnchor:bar.topAnchor constant:16],
+        [label.bottomAnchor constraintEqualToAnchor:bar.bottomAnchor constant:-16],
+        [close.trailingAnchor constraintEqualToAnchor:bar.trailingAnchor constant:-20],
+        [close.centerYAnchor constraintEqualToAnchor:bar.centerYAnchor],
+    ]];
+    return bar;
+}
+
+- (UIView *)makeFormFooter {
+    UILabel *hint = [UILabel new];
+    hint.text = @"Triggered by shaking the device.";
+    hint.font = [UIFont systemFontOfSize:13];
+    hint.textColor = [BSPDemoTheme textTertiary];
+    hint.textAlignment = NSTextAlignmentCenter;
+
+    self.sendButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.sendButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.sendButton setTitle:@"Send feedback  →" forState:UIControlStateNormal];
+    self.sendButton.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightBold];
+    [self.sendButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    self.sendButton.backgroundColor = [BSPDemoTheme feedbackAccent];
+    self.sendButton.layer.cornerRadius = 12;
+    self.sendButton.layer.cornerCurve = kCACornerCurveContinuous;
+    [self.sendButton.heightAnchor constraintEqualToConstant:52].active = YES;
+    [self.sendButton addTarget:self action:@selector(submitTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    self.sendSpinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    self.sendSpinner.translatesAutoresizingMaskIntoConstraints = NO;
+    self.sendSpinner.color = UIColor.whiteColor;
+    self.sendSpinner.hidesWhenStopped = YES;
+    [self.sendButton addSubview:self.sendSpinner];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.sendSpinner.centerXAnchor constraintEqualToAnchor:self.sendButton.centerXAnchor],
+        [self.sendSpinner.centerYAnchor constraintEqualToAnchor:self.sendButton.centerYAnchor],
+    ]];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ hint, self.sendButton ]];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 12;
+    stack.alignment = UIStackViewAlignmentFill;
+    stack.layoutMarginsRelativeArrangement = YES;
+    stack.layoutMargins = UIEdgeInsetsMake(14, 20, 20, 20);
+
+    return [self footerContainerWithContent:stack];
+}
+
+- (UIView *)footerContainerWithContent:(UIView *)content {
+    UIView *container = [UIView new];
+    container.translatesAutoresizingMaskIntoConstraints = NO;
+    container.backgroundColor = [BSPDemoTheme footerBg];
+    UIView *divider = [self makeDivider];
+    [container addSubview:divider];
+    [container addSubview:content];
+    [NSLayoutConstraint activateConstraints:@[
+        [divider.topAnchor constraintEqualToAnchor:container.topAnchor],
+        [divider.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+        [divider.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+        [content.topAnchor constraintEqualToAnchor:container.topAnchor],
+        [content.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+        [content.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+        [content.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+    ]];
+    return container;
+}
+
+- (void)buildAttachmentRow {
+    self.attachmentRow = [UIView new];
+    self.attachmentRow.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentRow.backgroundColor = [BSPDemoTheme cardBg];
+    self.attachmentRow.layer.cornerRadius = 10;
+    self.attachmentRow.layer.cornerCurve = kCACornerCurveContinuous;
+    self.attachmentRow.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+    self.attachmentRow.layer.borderWidth = 1;
+
+    self.attachmentTypeChip = [UILabel new];
+    self.attachmentTypeChip.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentTypeChip.font = [UIFont systemFontOfSize:11 weight:UIFontWeightSemibold];
+    self.attachmentTypeChip.textColor = [BSPDemoTheme textSecondary];
+    self.attachmentTypeChip.textAlignment = NSTextAlignmentCenter;
+    self.attachmentTypeChip.backgroundColor = [BSPDemoTheme badgeBg];
+    self.attachmentTypeChip.layer.cornerRadius = 8;
+    self.attachmentTypeChip.layer.masksToBounds = YES;
+
+    self.attachmentNameLabel = [UILabel new];
+    self.attachmentNameLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentNameLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+    self.attachmentNameLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+
+    self.attachmentDetailLabel = [UILabel new];
+    self.attachmentDetailLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentDetailLabel.font = [UIFont systemFontOfSize:12];
+    self.attachmentDetailLabel.textColor = [BSPDemoTheme textTertiary];
+
+    self.attachmentActionButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.attachmentActionButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentActionButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
+    [self.attachmentActionButton setTitleColor:[BSPDemoTheme link] forState:UIControlStateNormal];
+    [self.attachmentActionButton addTarget:self action:@selector(pickFileTapped) forControlEvents:UIControlEventTouchUpInside];
+    [self.attachmentActionButton setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+
+    UIStackView *textStack = [[UIStackView alloc] initWithArrangedSubviews:@[ self.attachmentNameLabel, self.attachmentDetailLabel ]];
+    textStack.translatesAutoresizingMaskIntoConstraints = NO;
+    textStack.axis = UILayoutConstraintAxisVertical;
+    textStack.spacing = 2;
+
+    [self.attachmentRow addSubview:self.attachmentTypeChip];
+    [self.attachmentRow addSubview:textStack];
+    [self.attachmentRow addSubview:self.attachmentActionButton];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.attachmentTypeChip.leadingAnchor constraintEqualToAnchor:self.attachmentRow.leadingAnchor constant:12],
+        [self.attachmentTypeChip.centerYAnchor constraintEqualToAnchor:self.attachmentRow.centerYAnchor],
+        [self.attachmentTypeChip.widthAnchor constraintEqualToConstant:44],
+        [self.attachmentTypeChip.heightAnchor constraintEqualToConstant:44],
+
+        [textStack.leadingAnchor constraintEqualToAnchor:self.attachmentTypeChip.trailingAnchor constant:12],
+        [textStack.centerYAnchor constraintEqualToAnchor:self.attachmentRow.centerYAnchor],
+
+        [self.attachmentActionButton.leadingAnchor constraintGreaterThanOrEqualToAnchor:textStack.trailingAnchor constant:8],
+        [self.attachmentActionButton.trailingAnchor constraintEqualToAnchor:self.attachmentRow.trailingAnchor constant:-12],
+        [self.attachmentActionButton.centerYAnchor constraintEqualToAnchor:self.attachmentRow.centerYAnchor],
+
+        [self.attachmentRow.heightAnchor constraintGreaterThanOrEqualToConstant:68],
+    ]];
+}
+
+- (void)renderAttachmentRow {
+    if (self.pickedFileName.length > 0 && self.pickedFileData) {
+        NSString *ext = self.pickedFileName.pathExtension.uppercaseString;
+        self.attachmentTypeChip.text = ext.length > 0 ? ext : @"FILE";
+        self.attachmentTypeChip.hidden = NO;
+        self.attachmentNameLabel.text = self.pickedFileName;
+        self.attachmentNameLabel.textColor = [BSPDemoTheme textPrimary];
+        self.attachmentDetailLabel.text = [NSByteCountFormatter stringFromByteCount:(long long)self.pickedFileData.length
+                                                                         countStyle:NSByteCountFormatterCountStyleFile];
+        self.attachmentDetailLabel.hidden = NO;
+        [self.attachmentActionButton setTitle:@"Replace" forState:UIControlStateNormal];
+    } else {
+        self.attachmentTypeChip.hidden = YES;
+        self.attachmentNameLabel.text = @"No file selected";
+        self.attachmentNameLabel.textColor = [BSPDemoTheme textTertiary];
+        self.attachmentDetailLabel.hidden = YES;
+        [self.attachmentActionButton setTitle:@"Add" forState:UIControlStateNormal];
+    }
+}
+
+- (UIView *)makeIncludeLogsRow {
+    UILabel *title = [UILabel new];
+    title.text = @"Include logs";
+    title.font = [UIFont systemFontOfSize:15 weight:UIFontWeightSemibold];
+    title.textColor = [BSPDemoTheme textPrimary];
+
+    UILabel *subtitle = [UILabel new];
+    subtitle.text = @"Attach the app's sample_log.txt";
+    subtitle.font = [UIFont systemFontOfSize:12];
+    subtitle.textColor = [BSPDemoTheme textTertiary];
+
+    UIStackView *textStack = [[UIStackView alloc] initWithArrangedSubviews:@[ title, subtitle ]];
+    textStack.axis = UILayoutConstraintAxisVertical;
+    textStack.spacing = 2;
+
+    self.includeLogsSwitch = [UISwitch new];
+    self.includeLogsSwitch.on = YES;
+    self.includeLogsSwitch.onTintColor = [BSPDemoTheme feedbackAccent];
+    [self.includeLogsSwitch setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+
+    UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[ textStack, self.includeLogsSwitch ]];
+    row.axis = UILayoutConstraintAxisHorizontal;
+    row.alignment = UIStackViewAlignmentCenter;
+    row.spacing = 12;
+    return row;
+}
+
+#pragma mark - Field helpers
+
+- (UITextField *)makeTextField {
+    UITextField *field = [UITextField new];
+    field.translatesAutoresizingMaskIntoConstraints = NO;
+    field.font = [UIFont systemFontOfSize:15];
+    field.textColor = [BSPDemoTheme textPrimary];
+    field.borderStyle = UITextBorderStyleNone;
+    field.delegate = self;
+    [field addTarget:self action:@selector(textChanged) forControlEvents:UIControlEventEditingChanged];
+    return field;
+}
+
+/// Wraps an input view in a rounded, outlined box.
+- (UIView *)boxedInput:(UIView *)input {
+    UIView *box = [UIView new];
+    box.translatesAutoresizingMaskIntoConstraints = NO;
+    box.backgroundColor = [BSPDemoTheme cardBg];
+    box.layer.cornerRadius = 10;
+    box.layer.cornerCurve = kCACornerCurveContinuous;
+    box.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+    box.layer.borderWidth = 1;
+    input.translatesAutoresizingMaskIntoConstraints = NO;
+    [box addSubview:input];
+    BOOL isTextView = [input isKindOfClass:[UITextView class]];
+    CGFloat vInset = isTextView ? 0 : 11;
+    CGFloat hInset = isTextView ? 0 : 12;
+    [NSLayoutConstraint activateConstraints:@[
+        [input.topAnchor constraintEqualToAnchor:box.topAnchor constant:vInset],
+        [input.bottomAnchor constraintEqualToAnchor:box.bottomAnchor constant:-vInset],
+        [input.leadingAnchor constraintEqualToAnchor:box.leadingAnchor constant:hInset],
+        [input.trailingAnchor constraintEqualToAnchor:box.trailingAnchor constant:-hInset],
+    ]];
+    if (!isTextView) {
+        [input.heightAnchor constraintGreaterThanOrEqualToConstant:22].active = YES;
+    }
+    return box;
+}
+
+/// A labeled field: a header row (label + red asterisk or "optional") above the input.
+- (UIView *)makeFieldWithLabel:(NSString *)label required:(BOOL)required input:(UIView *)input {
+    UILabel *labelView = [UILabel new];
+    NSMutableAttributedString *attributed = [[NSMutableAttributedString alloc]
+        initWithString:label
+            attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold],
+                          NSForegroundColorAttributeName: [BSPDemoTheme textPrimary] }];
+    if (required) {
+        [attributed appendAttributedString:[[NSAttributedString alloc]
+            initWithString:@" *"
+                attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold],
+                              NSForegroundColorAttributeName: [BSPDemoTheme asterisk] }]];
+    }
+    labelView.attributedText = attributed;
+
+    UIView *headerRow;
+    if (required) {
+        headerRow = labelView;
+    } else {
+        UILabel *optional = [UILabel new];
+        optional.text = @"optional";
+        optional.font = [UIFont systemFontOfSize:13];
+        optional.textColor = [BSPDemoTheme textTertiary];
+        UIView *spacer = [UIView new];
+        [spacer setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+        UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[ labelView, spacer, optional ]];
+        row.axis = UILayoutConstraintAxisHorizontal;
+        row.alignment = UIStackViewAlignmentFirstBaseline;
+        headerRow = row;
+    }
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ headerRow, input ]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 6;
+    stack.alignment = UIStackViewAlignmentFill;
+    return stack;
+}
+
+- (UIView *)makeDivider {
+    UIView *divider = [UIView new];
+    divider.translatesAutoresizingMaskIntoConstraints = NO;
+    divider.backgroundColor = [BSPDemoTheme cardStroke];
+    [divider.heightAnchor constraintEqualToConstant:1].active = YES;
+    return divider;
+}
+
+#pragma mark - Form actions
+
+- (void)textChanged {
+    [self updateSendEnabled];
+}
+
+- (void)closeTapped {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)updateSendEnabled {
+    NSString *trimmed = [self.titleField.text stringByTrimmingCharactersInSet:
+                         [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    BOOL enabled = trimmed.length > 0 && !self.submitting;
+    self.sendButton.enabled = enabled;
+    self.sendButton.alpha = enabled ? 1.0 : 0.45;
+}
+
+- (void)pickFileTapped {
+    UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc]
+        initForOpeningContentTypes:@[ UTTypeItem ] asCopy:YES];
+    picker.delegate = self;
+    picker.allowsMultipleSelection = NO;
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+- (void)setSubmitting:(BOOL)submitting {
+    _submitting = submitting;
+    if (submitting) {
+        [self.sendButton setTitle:@"" forState:UIControlStateNormal];
+        [self.sendSpinner startAnimating];
+    } else {
+        [self.sendButton setTitle:@"Send feedback  →" forState:UIControlStateNormal];
+        [self.sendSpinner stopAnimating];
+    }
+    self.segmented.enabled = !submitting;
+    self.titleField.enabled = !submitting;
+    self.descriptionView.editable = !submitting;
+    self.nameField.enabled = !submitting;
+    self.emailField.enabled = !submitting;
+    self.includeLogsSwitch.enabled = !submitting;
+    self.attachmentActionButton.enabled = !submitting;
+    [self updateSendEnabled];
+}
+
+- (void)submitTapped {
+    NSString *trimmedTitle = [self.titleField.text stringByTrimmingCharactersInSet:
+                              [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmedTitle.length == 0) return;
+
+    self.errorLabel.hidden = YES;
+    [self setSubmitting:YES];
+
+    NSMutableArray<BugSplatAttachment *> *attachments = [NSMutableArray array];
+    if (self.pickedFileName.length > 0 && self.pickedFileData) {
+        UTType *type = [UTType typeWithFilenameExtension:self.pickedFileName.pathExtension];
+        NSString *mime = type.preferredMIMEType ?: @"application/octet-stream";
+        [attachments addObject:[[BugSplatAttachment alloc] initWithFilename:self.pickedFileName
+                                                             attachmentData:self.pickedFileData
+                                                                contentType:mime]];
+    }
+    if (self.includeLogsSwitch.isOn) {
+        BugSplatAttachment *log = [BSPSampleLog attachment];
+        if (log) [attachments addObject:log];
+    }
+
+    NSString *descText = self.descriptionView.text;
+    NSString *name = self.nameField.text;
+    NSString *email = self.emailField.text;
+
+    __weak typeof(self) weakSelf = self;
+    [[BugSplat shared] postFeedback:trimmedTitle
+                        description:descText.length > 0 ? descText : nil
+                           userName:name.length > 0 ? name : nil
+                          userEmail:email.length > 0 ? email : nil
+                             appKey:nil
+                         attributes:@{ @"category": [self selectedCategory] }
+                        attachments:attachments.count > 0 ? attachments : nil
+                         completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            [strongSelf setSubmitting:NO];
+            if (error) {
+                strongSelf.errorLabel.text = [NSString stringWithFormat:@"Feedback failed: %@",
+                                              error.localizedDescription];
+                strongSelf.errorLabel.hidden = NO;
+            } else {
+                NSString *detail = [NSString stringWithFormat:@"“%@”", trimmedTitle];
+                [BSPActivityLog record:BSPActivityTypeFeedback detail:detail];
+                [strongSelf showThanksWithResult:result];
+            }
+        });
+    }];
+}
+
+#pragma mark - Thank-you screen
+
+- (void)buildThanksContainer {
+    self.thanksContainer = [UIView new];
+    self.thanksContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    self.thanksContainer.backgroundColor = [BSPDemoTheme cardBg];
+    self.thanksContainer.hidden = YES;
+    [self.view addSubview:self.thanksContainer];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.thanksContainer.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.thanksContainer.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.thanksContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.thanksContainer.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    ]];
+}
+
+- (void)showThanksWithResult:(BugSplatFeedbackResult *)result {
+    NSString *reportId = result.crashId ? result.crashId.stringValue : nil;
+
+    UIView *circle = [UIView new];
+    circle.translatesAutoresizingMaskIntoConstraints = NO;
+    circle.backgroundColor = [[BSPDemoTheme feedbackAccent] colorWithAlphaComponent:0.14];
+    circle.layer.cornerRadius = 42;
+    circle.layer.borderColor = [[BSPDemoTheme feedbackAccent] colorWithAlphaComponent:0.35].CGColor;
+    circle.layer.borderWidth = 1;
+    UIImageConfiguration *checkConfig = [UIImageSymbolConfiguration configurationWithPointSize:32
+                                                                                       weight:UIImageSymbolWeightBold];
+    UIImageView *check = [[UIImageView alloc] initWithImage:
+        [UIImage systemImageNamed:@"checkmark" withConfiguration:checkConfig]];
+    check.tintColor = [BSPDemoTheme feedbackAccent];
+    check.translatesAutoresizingMaskIntoConstraints = NO;
+    [circle addSubview:check];
+    [NSLayoutConstraint activateConstraints:@[
+        [circle.widthAnchor constraintEqualToConstant:84],
+        [circle.heightAnchor constraintEqualToConstant:84],
+        [check.centerXAnchor constraintEqualToAnchor:circle.centerXAnchor],
+        [check.centerYAnchor constraintEqualToAnchor:circle.centerYAnchor],
+    ]];
+    UIView *circleWrap = [UIView new];
+    [circleWrap addSubview:circle];
+    [NSLayoutConstraint activateConstraints:@[
+        [circle.topAnchor constraintEqualToAnchor:circleWrap.topAnchor],
+        [circle.bottomAnchor constraintEqualToAnchor:circleWrap.bottomAnchor],
+        [circle.centerXAnchor constraintEqualToAnchor:circleWrap.centerXAnchor],
+    ]];
+
+    UILabel *titleLabel = [UILabel new];
+    titleLabel.text = @"Feedback sent. Thanks!";
+    titleLabel.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+    titleLabel.textColor = [BSPDemoTheme textPrimary];
+    titleLabel.textAlignment = NSTextAlignmentCenter;
+
+    UILabel *messageLabel = [UILabel new];
+    messageLabel.text = @"Your note made it to the BugSplat team. We reply within a day.";
+    messageLabel.font = [UIFont systemFontOfSize:15];
+    messageLabel.textColor = [BSPDemoTheme textSecondary];
+    messageLabel.textAlignment = NSTextAlignmentCenter;
+    messageLabel.numberOfLines = 0;
+
+    UIView *reportRow = [self makeReportIdRow:reportId];
+
+    UIStackView *topStack = [[UIStackView alloc] initWithArrangedSubviews:@[ circleWrap, titleLabel, messageLabel, reportRow ]];
+    topStack.translatesAutoresizingMaskIntoConstraints = NO;
+    topStack.axis = UILayoutConstraintAxisVertical;
+    topStack.alignment = UIStackViewAlignmentFill;
+    topStack.spacing = 16;
+    [topStack setCustomSpacing:20 afterView:messageLabel];
+
+    UIView *footer = [self makeThanksFooterWithResult:result];
+
+    [self.thanksContainer addSubview:topStack];
+    [self.thanksContainer addSubview:footer];
+    [NSLayoutConstraint activateConstraints:@[
+        [topStack.centerYAnchor constraintEqualToAnchor:self.thanksContainer.centerYAnchor constant:-40],
+        [topStack.leadingAnchor constraintEqualToAnchor:self.thanksContainer.leadingAnchor constant:24],
+        [topStack.trailingAnchor constraintEqualToAnchor:self.thanksContainer.trailingAnchor constant:-24],
+
+        [footer.leadingAnchor constraintEqualToAnchor:self.thanksContainer.leadingAnchor],
+        [footer.trailingAnchor constraintEqualToAnchor:self.thanksContainer.trailingAnchor],
+        [footer.bottomAnchor constraintEqualToAnchor:self.thanksContainer.bottomAnchor],
+    ]];
+
+    self.thanksContainer.alpha = 0;
+    self.thanksContainer.hidden = NO;
+    [UIView transitionWithView:self.view
+                      duration:0.3
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:^{
+        self.formContainer.hidden = YES;
+        self.thanksContainer.alpha = 1;
+    } completion:nil];
+}
+
+- (UIView *)makeReportIdRow:(nullable NSString *)reportId {
+    UILabel *label = [UILabel new];
+    label.attributedText = [[NSAttributedString alloc]
+        initWithString:@"REPORT ID"
+            attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:11 weight:UIFontWeightSemibold],
+                          NSForegroundColorAttributeName: [BSPDemoTheme textTertiary],
+                          NSKernAttributeName: @1.1 }];
+
+    UILabel *idLabel = [UILabel new];
+    idLabel.text = reportId ?: @"Unavailable";
+    idLabel.font = [UIFont monospacedSystemFontOfSize:15 weight:UIFontWeightMedium];
+    idLabel.textColor = [BSPDemoTheme textPrimary];
+
+    UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[ label, idLabel ]];
+    row.axis = UILayoutConstraintAxisHorizontal;
+    row.spacing = 12;
+    row.alignment = UIStackViewAlignmentCenter;
+    row.translatesAutoresizingMaskIntoConstraints = NO;
+
+    if (reportId) {
+        UIButton *copy = [UIButton buttonWithType:UIButtonTypeSystem];
+        [copy setTitle:@"Copy" forState:UIControlStateNormal];
+        [copy setImage:[UIImage systemImageNamed:@"doc.on.doc"] forState:UIControlStateNormal];
+        copy.titleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+        copy.tintColor = [BSPDemoTheme textSecondary];
+        [copy setTitleColor:[BSPDemoTheme textSecondary] forState:UIControlStateNormal];
+        copy.backgroundColor = [BSPDemoTheme cardBg];
+        copy.layer.cornerRadius = 8;
+        copy.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+        copy.layer.borderWidth = 1;
+        copy.contentEdgeInsets = UIEdgeInsetsMake(7, 12, 7, 12);
+        copy.titleEdgeInsets = UIEdgeInsetsMake(0, 5, 0, 0);
+        [copy setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+        [copy addAction:[UIAction actionWithHandler:^(UIAction *action) {
+            UIPasteboard.generalPasteboard.string = reportId;
+        }] forControlEvents:UIControlEventTouchUpInside];
+        UIView *spacer = [UIView new];
+        [spacer setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+        [row addArrangedSubview:spacer];
+        [row addArrangedSubview:copy];
+    }
+
+    UIView *card = [UIView new];
+    card.translatesAutoresizingMaskIntoConstraints = NO;
+    card.backgroundColor = [BSPDemoTheme badgeBg];
+    card.layer.cornerRadius = 12;
+    card.layer.cornerCurve = kCACornerCurveContinuous;
+    [card addSubview:row];
+    [NSLayoutConstraint activateConstraints:@[
+        [row.topAnchor constraintEqualToAnchor:card.topAnchor constant:14],
+        [row.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-14],
+        [row.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:16],
+        [row.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-16],
+    ]];
+    return card;
+}
+
+- (UIView *)makeThanksFooterWithResult:(BugSplatFeedbackResult *)result {
+    UIButton *dashboard = [UIButton buttonWithType:UIButtonTypeSystem];
+    dashboard.translatesAutoresizingMaskIntoConstraints = NO;
+    [dashboard setTitle:@"View on dashboard  ↗" forState:UIControlStateNormal];
+    dashboard.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightBold];
+    [dashboard setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    dashboard.backgroundColor = [BSPDemoTheme feedbackAccent];
+    dashboard.layer.cornerRadius = 12;
+    dashboard.layer.cornerCurve = kCACornerCurveContinuous;
+    [dashboard.heightAnchor constraintEqualToConstant:52].active = YES;
+    [dashboard addAction:[UIAction actionWithHandler:^(UIAction *action) {
+        [self openReportWithResult:result];
+    }] forControlEvents:UIControlEventTouchUpInside];
+
+    UIButton *close = [UIButton buttonWithType:UIButtonTypeSystem];
+    [close setTitle:@"Close" forState:UIControlStateNormal];
+    close.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    [close setTitleColor:[BSPDemoTheme textSecondary] forState:UIControlStateNormal];
+    [close addTarget:self action:@selector(closeTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ dashboard, close, [self makePoweredByView] ]];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 14;
+    stack.alignment = UIStackViewAlignmentFill;
+    stack.layoutMarginsRelativeArrangement = YES;
+    stack.layoutMargins = UIEdgeInsetsMake(14, 20, 20, 20);
+
+    return [self footerContainerWithContent:stack];
+}
+
+/// "Powered by BugSplat" where the word BugSplat links to bugsplat.com.
+- (UIView *)makePoweredByView {
+    UILabel *prefix = [UILabel new];
+    prefix.text = @"Powered by";
+    prefix.font = [UIFont systemFontOfSize:13];
+    prefix.textColor = [BSPDemoTheme textTertiary];
+
+    UIButton *link = [UIButton buttonWithType:UIButtonTypeSystem];
+    [link setTitle:@"BugSplat" forState:UIControlStateNormal];
+    link.titleLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+    [link setTitleColor:[BSPDemoTheme link] forState:UIControlStateNormal];
+    link.contentEdgeInsets = UIEdgeInsetsZero;
+    [link addAction:[UIAction actionWithHandler:^(UIAction *action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://bugsplat.com"]
+                                           options:@{} completionHandler:nil];
+    }] forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[ prefix, link ]];
+    row.axis = UILayoutConstraintAxisHorizontal;
+    row.spacing = 4;
+    row.alignment = UIStackViewAlignmentCenter;
+
+    UIView *leftSpacer = [UIView new];
+    UIView *rightSpacer = [UIView new];
+    UIStackView *centered = [[UIStackView alloc] initWithArrangedSubviews:@[ leftSpacer, row, rightSpacer ]];
+    centered.axis = UILayoutConstraintAxisHorizontal;
+    centered.distribution = UIStackViewDistributionEqualCentering;
+    return centered;
+}
+
+/// Links directly to the report by id. Feedback reports group by their (unique)
+/// title, so the SDK's infoUrl resolves to a generic page — prefer the id-scoped
+/// crash URL, falling back to the database dashboard.
+- (void)openReportWithResult:(BugSplatFeedbackResult *)result {
+    NSURLComponents *components;
+    if (result.crashId) {
+        components = [NSURLComponents componentsWithString:@"https://app.bugsplat.com/v2/crash"];
+        components.queryItems = @[
+            [NSURLQueryItem queryItemWithName:@"database" value:[self database]],
+            [NSURLQueryItem queryItemWithName:@"id" value:result.crashId.stringValue],
+        ];
+    } else {
+        components = [NSURLComponents componentsWithString:@"https://app.bugsplat.com/v2/dashboard"];
+        components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"database" value:[self database]] ];
+    }
+    NSURL *url = components.URL;
+    if (url) {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    }
+}
+
+#pragma mark - UIDocumentPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller
+    didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+    NSURL *url = urls.firstObject;
+    if (!url) return;
+    BOOL scoped = [url startAccessingSecurityScopedResource];
+    NSError *error = nil;
+    NSData *data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+    if (scoped) [url stopAccessingSecurityScopedResource];
+    if (data) {
+        self.pickedFileData = data;
+        self.pickedFileName = url.lastPathComponent;
+        [self renderAttachmentRow];
+    } else {
+        self.errorLabel.text = [NSString stringWithFormat:@"Couldn't read the selected file: %@",
+                                error.localizedDescription];
+        self.errorLabel.hidden = NO;
+    }
+}
+
+@end

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/BSPFeedbackViewController.m
@@ -227,12 +227,6 @@
 }
 
 - (UIView *)makeFormFooter {
-    UILabel *hint = [UILabel new];
-    hint.text = @"Triggered by shaking the device.";
-    hint.font = [UIFont systemFontOfSize:13];
-    hint.textColor = [BSPDemoTheme textTertiary];
-    hint.textAlignment = NSTextAlignmentCenter;
-
     self.sendButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.sendButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.sendButton setTitle:@"Send feedback  →" forState:UIControlStateNormal];
@@ -254,13 +248,13 @@
         [self.sendSpinner.centerYAnchor constraintEqualToAnchor:self.sendButton.centerYAnchor],
     ]];
 
-    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ hint, self.sendButton ]];
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[ self.sendButton ]];
     stack.translatesAutoresizingMaskIntoConstraints = NO;
     stack.axis = UILayoutConstraintAxisVertical;
     stack.spacing = 12;
     stack.alignment = UIStackViewAlignmentFill;
     stack.layoutMarginsRelativeArrangement = YES;
-    stack.layoutMargins = UIEdgeInsetsMake(14, 20, 20, 20);
+    stack.layoutMargins = UIEdgeInsetsMake(20, 20, 20, 20);
 
     return [self footerContainerWithContent:stack];
 }

--- a/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-UIKit-ObjC/BugSplatTest-UIKit-ObjC/ViewController.m
@@ -14,6 +14,7 @@
 #import "BSPActivityLog.h"
 #import "BSPDemoTheme.h"
 #import "BSPDemoViews.h"
+#import "BSPFeedbackViewController.h"
 
 @interface ViewController ()
 
@@ -30,9 +31,6 @@
 
 // Footer line at the bottom of the scroll view.
 @property (nonatomic, strong) UILabel *footerLabel;
-
-// Sticky session-only feedback status message (matches SwiftUI feedbackStatus).
-@property (nonatomic, copy, nullable) NSString *feedbackStatus;
 
 @end
 
@@ -404,15 +402,6 @@
     }
 }
 
-#pragma mark - Footer
-
-- (void)setFeedbackStatus:(NSString *)feedbackStatus {
-    _feedbackStatus = [feedbackStatus copy];
-    self.footerLabel.text = feedbackStatus.length > 0
-        ? feedbackStatus
-        : @"Shake the device to send feedback anytime.";
-}
-
 #pragma mark - Actions
 
 - (void)triggerCrash {
@@ -467,62 +456,19 @@
 }
 
 - (void)showFeedbackDialog {
-    UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"Send Feedback"
-                         message:nil
-                  preferredStyle:UIAlertControllerStyleAlert];
-    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.placeholder = @"Title";
-    }];
-    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.placeholder = @"Description";
-    }];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
-                                              style:UIAlertActionStyleCancel
-                                            handler:nil]];
+    // Don't stack a second feedback sheet if one is already showing (e.g. a
+    // shake while the sheet is up).
+    if ([self.presentedViewController isKindOfClass:[BSPFeedbackViewController class]]) return;
+    BSPFeedbackViewController *feedback = [[BSPFeedbackViewController alloc] init];
+    feedback.modalPresentationStyle = UIModalPresentationPageSheet;
     __weak typeof(self) weakSelf = self;
-    [alert addAction:[UIAlertAction actionWithTitle:@"Send"
-                                              style:UIAlertActionStyleDefault
-                                            handler:^(UIAlertAction *action) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) return;
-        NSString *title = alert.textFields[0].text ?: @"";
-        NSString *descText = alert.textFields[1].text ?: @"";
-        NSString *description = descText.length > 0 ? descText : nil;
-        [strongSelf sendFeedbackWithTitle:title description:description];
-    }]];
-    [self presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)sendFeedbackWithTitle:(NSString *)title description:(NSString *)description {
-    NSString *trimmed = [title stringByTrimmingCharactersInSet:
-                         [NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    // Treat an empty title the same as Cancel - don't submit, don't record.
-    if (trimmed.length == 0) return;
-
-    self.feedbackStatus = @"Sending...";
-    __weak typeof(self) weakSelf = self;
-    [[BugSplat shared] postFeedback:trimmed
-                        description:description
-                           userName:nil
-                          userEmail:nil
-                             appKey:nil
-                        attachments:nil
-                         completion:^(NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (!strongSelf) return;
-            if (error) {
-                strongSelf.feedbackStatus = [NSString stringWithFormat:@"Feedback failed: %@",
-                                              error.localizedDescription];
-            } else {
-                strongSelf.feedbackStatus = @"Feedback sent — thank you!";
-                NSString *detail = [NSString stringWithFormat:@"“%@”", trimmed];
-                [BSPActivityLog record:BSPActivityTypeFeedback detail:detail];
-                [strongSelf refreshRecentActivity];
-            }
-        });
-    }];
+    feedback.onDismiss = ^{ [weakSelf refreshRecentActivity]; };
+    UISheetPresentationController *sheet = feedback.sheetPresentationController;
+    if (sheet) {
+        sheet.detents = @[ [UISheetPresentationControllerDetent largeDetent] ];
+        sheet.prefersGrabberVisible = YES;
+    }
+    [self presentViewController:feedback animated:YES completion:nil];
 }
 
 - (void)openDashboard {

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		64D000AC10010000000000A2 /* ActivityLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D000AC10010000000000A1 /* ActivityLog.swift */; };
 		64D000AC10010000000000B2 /* DemoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D000AC10010000000000B1 /* DemoTheme.swift */; };
 		64D000AC10010000000000C2 /* DemoViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D000AC10010000000000C1 /* DemoViews.swift */; };
+		FEEDBAC020010000000000B1 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC020010000000000B2 /* FeedbackViewController.swift */; };
 		6383C72A2BDB1BEF00ABC887 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6383C7292BDB1BEF00ABC887 /* Base */; };
 		6383C72C2BDB1BF100ABC887 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6383C72B2BDB1BF100ABC887 /* Assets.xcassets */; };
 		6383C72F2BDB1BF100ABC887 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6383C72E2BDB1BF100ABC887 /* Base */; };
@@ -42,6 +43,7 @@
 		64D000AC10010000000000A1 /* ActivityLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLog.swift; sourceTree = "<group>"; };
 		64D000AC10010000000000B1 /* DemoTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTheme.swift; sourceTree = "<group>"; };
 		64D000AC10010000000000C1 /* DemoViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoViews.swift; sourceTree = "<group>"; };
+		FEEDBAC020010000000000B2 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		6383C7292BDB1BEF00ABC887 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		6383C72B2BDB1BF100ABC887 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6383C72E2BDB1BF100ABC887 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				64D000AC10010000000000A1 /* ActivityLog.swift */,
 				64D000AC10010000000000B1 /* DemoTheme.swift */,
 				64D000AC10010000000000C1 /* DemoViews.swift */,
+				FEEDBAC020010000000000B2 /* FeedbackViewController.swift */,
 				6383C7282BDB1BEF00ABC887 /* Main.storyboard */,
 				6383C72B2BDB1BF100ABC887 /* Assets.xcassets */,
 				6383C72D2BDB1BF100ABC887 /* LaunchScreen.storyboard */,
@@ -202,6 +205,7 @@
 				64D000AC10010000000000A2 /* ActivityLog.swift in Sources */,
 				64D000AC10010000000000B2 /* DemoTheme.swift in Sources */,
 				64D000AC10010000000000C2 /* DemoViews.swift in Sources */,
+				FEEDBAC020010000000000B1 /* FeedbackViewController.swift in Sources */,
 				6383C7232BDB1BEF00ABC887 /* AppDelegate.swift in Sources */,
 				6383C7252BDB1BEF00ABC887 /* SceneDelegate.swift in Sources */,
 			);

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/DemoTheme.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/DemoTheme.swift
@@ -21,6 +21,10 @@ enum DemoColor {
     static let pillStroke   = UIColor(hex: 0xE4E2DA)
     static let connectedDot = UIColor(hex: 0x22C55E)
     static let link         = UIColor(hex: 0x1F73E8)
+    // Primary action green used by the feedback sheet (form + thank-you buttons).
+    static let feedbackAccent = UIColor(hex: 0x4E9D78)
+    static let footerBg     = UIColor(hex: 0xF4F2EA)
+    static let asterisk     = UIColor(hex: 0xDC2626)
 
     static let activityCrash    = UIColor(hex: 0x1F73E8)
     static let activityError    = UIColor(hex: 0xE5B142)

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
@@ -1,0 +1,794 @@
+//
+//  FeedbackViewController.swift
+//  BugSplatTest-UIKit-Swift
+//
+//  The redesigned User Feedback experience: a bottom-sheet form for composing
+//  feedback, and a thank-you confirmation shown in the same sheet after a
+//  successful submit. Mirrors the bugsplat-android demo refresh.
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+import UIKit
+import UniformTypeIdentifiers
+import BugSplat
+
+/// Feedback category shown in the segmented selector. The raw value is sent to
+/// BugSplat as the `category` custom attribute.
+enum FeedbackCategory: String, CaseIterable {
+    case bug = "Bug"
+    case feature = "Feature"
+    case other = "Other"
+}
+
+/// Locates the `sample_log.txt` file the app writes at launch (see `AppDelegate`)
+/// so it can be attached to feedback when the user opts in.
+enum SampleLog {
+    static var fileURL: URL? {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("sample_log.txt")
+    }
+
+    static func attachment() -> BugSplatAttachment? {
+        guard let url = fileURL, let data = try? Data(contentsOf: url) else { return nil }
+        return BugSplatAttachment(filename: "sample_log.txt",
+                                  attachmentData: data,
+                                  contentType: "text/plain")
+    }
+}
+
+final class FeedbackViewController: UIViewController {
+
+    /// Called after the sheet is dismissed so the presenter can refresh state
+    /// (a page-sheet dismissal does not trigger the presenter's viewWillAppear).
+    var onDismiss: (() -> Void)?
+
+    // MARK: - State
+
+    private var category: FeedbackCategory = .bug
+    private var pickedFileName: String?
+    private var pickedFileData: Data?
+    private var isSubmitting = false
+
+    private var database: String {
+        BugSplat.shared().bugSplatDatabase ?? "—"
+    }
+
+    // MARK: - Views
+
+    private let formContainer = UIView()
+    private let thanksContainer = UIView()
+
+    private let segmented = UISegmentedControl(items: FeedbackCategory.allCases.map { $0.rawValue })
+    private let titleField = UITextField()
+    private let descriptionView = UITextView()
+    private let nameField = UITextField()
+    private let emailField = UITextField()
+    private let includeLogsSwitch = UISwitch()
+    private let errorLabel = UILabel()
+    private let sendButton = UIButton(type: .system)
+    private let sendSpinner = UIActivityIndicatorView(style: .medium)
+
+    private let attachmentRow = UIView()
+    private let attachmentTypeChip = UILabel()
+    private let attachmentNameLabel = UILabel()
+    private let attachmentDetailLabel = UILabel()
+    private let attachmentActionButton = UIButton(type: .system)
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = DemoColor.cardBg
+        buildForm()
+        buildThanksPlaceholder()
+        renderAttachmentRow()
+        updateSendEnabled()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        onDismiss?()
+    }
+
+    // MARK: - Form layout
+
+    private func buildForm() {
+        formContainer.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(formContainer)
+        NSLayoutConstraint.activate([
+            formContainer.topAnchor.constraint(equalTo: view.topAnchor),
+            formContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            formContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            formContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        // Header
+        let header = makeHeader(title: "Send feedback")
+        let headerDivider = makeDivider()
+
+        // Footer (hint + send button)
+        let footer = makeFormFooter()
+
+        // Scrollable field content
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.keyboardDismissMode = .interactive
+
+        let fields = UIStackView()
+        fields.translatesAutoresizingMaskIntoConstraints = false
+        fields.axis = .vertical
+        fields.spacing = 18
+        fields.alignment = .fill
+
+        segmented.selectedSegmentIndex = 0
+        segmented.addTarget(self, action: #selector(categoryChanged), for: .valueChanged)
+        fields.addArrangedSubview(segmented)
+
+        configureTextField(titleField)
+        fields.addArrangedSubview(makeField(label: "Title", required: true, input: boxed(titleField)))
+
+        descriptionView.font = .systemFont(ofSize: 15)
+        descriptionView.textColor = DemoColor.textPrimary
+        descriptionView.backgroundColor = .clear
+        descriptionView.isScrollEnabled = false
+        descriptionView.textContainerInset = UIEdgeInsets(top: 7, left: 8, bottom: 7, right: 8)
+        descriptionView.heightAnchor.constraint(greaterThanOrEqualToConstant: 92).isActive = true
+        fields.addArrangedSubview(makeField(label: "Description", required: false, input: boxed(descriptionView)))
+
+        configureTextField(nameField)
+        nameField.textContentType = .name
+        fields.addArrangedSubview(makeField(label: "Name", required: false, input: boxed(nameField)))
+
+        configureTextField(emailField)
+        emailField.textContentType = .emailAddress
+        emailField.keyboardType = .emailAddress
+        emailField.autocapitalizationType = .none
+        fields.addArrangedSubview(makeField(label: "Email", required: false, input: boxed(emailField)))
+
+        buildAttachmentRow()
+        fields.addArrangedSubview(makeField(label: "Attachment", required: false, input: attachmentRow))
+
+        fields.addArrangedSubview(makeIncludeLogsRow())
+
+        errorLabel.font = .systemFont(ofSize: 13)
+        errorLabel.textColor = DemoColor.asterisk
+        errorLabel.numberOfLines = 0
+        errorLabel.isHidden = true
+        fields.addArrangedSubview(errorLabel)
+
+        scrollView.addSubview(fields)
+
+        let layout = UIStackView(arrangedSubviews: [header, headerDivider, scrollView, footer])
+        layout.translatesAutoresizingMaskIntoConstraints = false
+        layout.axis = .vertical
+        layout.alignment = .fill
+        formContainer.addSubview(layout)
+
+        NSLayoutConstraint.activate([
+            layout.topAnchor.constraint(equalTo: formContainer.safeAreaLayoutGuide.topAnchor),
+            layout.leadingAnchor.constraint(equalTo: formContainer.leadingAnchor),
+            layout.trailingAnchor.constraint(equalTo: formContainer.trailingAnchor),
+            layout.bottomAnchor.constraint(equalTo: formContainer.bottomAnchor),
+
+            fields.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 20),
+            fields.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -20),
+            fields.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 20),
+            fields.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -20),
+            fields.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -40),
+        ])
+    }
+
+    private func makeHeader(title: String) -> UIView {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.textColor = DemoColor.textPrimary
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let close = UIButton(type: .system)
+        close.translatesAutoresizingMaskIntoConstraints = false
+        close.setImage(UIImage(systemName: "xmark"), for: .normal)
+        close.tintColor = DemoColor.textSecondary
+        close.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+
+        let bar = UIView()
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.addSubview(label)
+        bar.addSubview(close)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: bar.leadingAnchor, constant: 20),
+            label.centerYAnchor.constraint(equalTo: bar.centerYAnchor),
+            label.topAnchor.constraint(equalTo: bar.topAnchor, constant: 16),
+            label.bottomAnchor.constraint(equalTo: bar.bottomAnchor, constant: -16),
+            close.trailingAnchor.constraint(equalTo: bar.trailingAnchor, constant: -20),
+            close.centerYAnchor.constraint(equalTo: bar.centerYAnchor),
+        ])
+        return bar
+    }
+
+    private func makeFormFooter() -> UIView {
+        let hint = UILabel()
+        hint.text = "Triggered by shaking the device."
+        hint.font = .systemFont(ofSize: 13)
+        hint.textColor = DemoColor.textTertiary
+        hint.textAlignment = .center
+
+        sendButton.translatesAutoresizingMaskIntoConstraints = false
+        sendButton.setTitle("Send feedback  →", for: .normal)
+        sendButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
+        sendButton.setTitleColor(.white, for: .normal)
+        sendButton.backgroundColor = DemoColor.feedbackAccent
+        sendButton.layer.cornerRadius = 12
+        sendButton.layer.cornerCurve = .continuous
+        sendButton.heightAnchor.constraint(equalToConstant: 52).isActive = true
+        sendButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
+
+        sendSpinner.translatesAutoresizingMaskIntoConstraints = false
+        sendSpinner.color = .white
+        sendSpinner.hidesWhenStopped = true
+        sendButton.addSubview(sendSpinner)
+        NSLayoutConstraint.activate([
+            sendSpinner.centerXAnchor.constraint(equalTo: sendButton.centerXAnchor),
+            sendSpinner.centerYAnchor.constraint(equalTo: sendButton.centerYAnchor),
+        ])
+
+        let stack = UIStackView(arrangedSubviews: [hint, sendButton])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .fill
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.layoutMargins = UIEdgeInsets(top: 14, left: 20, bottom: 20, right: 20)
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = DemoColor.footerBg
+        let divider = makeDivider()
+        container.addSubview(divider)
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            divider.topAnchor.constraint(equalTo: container.topAnchor),
+            divider.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return container
+    }
+
+    private func buildAttachmentRow() {
+        attachmentRow.translatesAutoresizingMaskIntoConstraints = false
+        attachmentRow.backgroundColor = DemoColor.cardBg
+        attachmentRow.layer.cornerRadius = 10
+        attachmentRow.layer.cornerCurve = .continuous
+        attachmentRow.layer.borderColor = DemoColor.cardStroke.cgColor
+        attachmentRow.layer.borderWidth = 1
+
+        attachmentTypeChip.translatesAutoresizingMaskIntoConstraints = false
+        attachmentTypeChip.font = .systemFont(ofSize: 11, weight: .semibold)
+        attachmentTypeChip.textColor = DemoColor.textSecondary
+        attachmentTypeChip.textAlignment = .center
+        attachmentTypeChip.backgroundColor = DemoColor.badgeBg
+        attachmentTypeChip.layer.cornerRadius = 8
+        attachmentTypeChip.layer.masksToBounds = true
+
+        attachmentNameLabel.translatesAutoresizingMaskIntoConstraints = false
+        attachmentNameLabel.font = .systemFont(ofSize: 14, weight: .medium)
+        attachmentNameLabel.textColor = DemoColor.textPrimary
+        attachmentNameLabel.lineBreakMode = .byTruncatingMiddle
+
+        attachmentDetailLabel.translatesAutoresizingMaskIntoConstraints = false
+        attachmentDetailLabel.font = .systemFont(ofSize: 12)
+        attachmentDetailLabel.textColor = DemoColor.textTertiary
+
+        attachmentActionButton.translatesAutoresizingMaskIntoConstraints = false
+        attachmentActionButton.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
+        attachmentActionButton.setTitleColor(DemoColor.link, for: .normal)
+        attachmentActionButton.addTarget(self, action: #selector(pickFileTapped), for: .touchUpInside)
+        attachmentActionButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        let textStack = UIStackView(arrangedSubviews: [attachmentNameLabel, attachmentDetailLabel])
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        attachmentRow.addSubview(attachmentTypeChip)
+        attachmentRow.addSubview(textStack)
+        attachmentRow.addSubview(attachmentActionButton)
+
+        NSLayoutConstraint.activate([
+            attachmentTypeChip.leadingAnchor.constraint(equalTo: attachmentRow.leadingAnchor, constant: 12),
+            attachmentTypeChip.centerYAnchor.constraint(equalTo: attachmentRow.centerYAnchor),
+            attachmentTypeChip.widthAnchor.constraint(equalToConstant: 44),
+            attachmentTypeChip.heightAnchor.constraint(equalToConstant: 44),
+
+            textStack.leadingAnchor.constraint(equalTo: attachmentTypeChip.trailingAnchor, constant: 12),
+            textStack.centerYAnchor.constraint(equalTo: attachmentRow.centerYAnchor),
+
+            attachmentActionButton.leadingAnchor.constraint(greaterThanOrEqualTo: textStack.trailingAnchor, constant: 8),
+            attachmentActionButton.trailingAnchor.constraint(equalTo: attachmentRow.trailingAnchor, constant: -12),
+            attachmentActionButton.centerYAnchor.constraint(equalTo: attachmentRow.centerYAnchor),
+
+            attachmentRow.heightAnchor.constraint(greaterThanOrEqualToConstant: 68),
+        ])
+    }
+
+    private func renderAttachmentRow() {
+        if let name = pickedFileName, let data = pickedFileData {
+            let ext = (name as NSString).pathExtension.uppercased()
+            attachmentTypeChip.text = ext.isEmpty ? "FILE" : ext
+            attachmentTypeChip.isHidden = false
+            attachmentNameLabel.text = name
+            attachmentDetailLabel.text = ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)
+            attachmentDetailLabel.isHidden = false
+            attachmentActionButton.setTitle("Replace", for: .normal)
+        } else {
+            attachmentTypeChip.isHidden = true
+            attachmentNameLabel.text = "No file selected"
+            attachmentNameLabel.textColor = DemoColor.textTertiary
+            attachmentDetailLabel.isHidden = true
+            attachmentActionButton.setTitle("Add", for: .normal)
+        }
+    }
+
+    private func makeIncludeLogsRow() -> UIView {
+        let title = UILabel()
+        title.text = "Include logs"
+        title.font = .systemFont(ofSize: 15, weight: .semibold)
+        title.textColor = DemoColor.textPrimary
+
+        let subtitle = UILabel()
+        subtitle.text = "Attach the app's sample_log.txt"
+        subtitle.font = .systemFont(ofSize: 12)
+        subtitle.textColor = DemoColor.textTertiary
+
+        let textStack = UIStackView(arrangedSubviews: [title, subtitle])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+
+        includeLogsSwitch.isOn = true
+        includeLogsSwitch.onTintColor = DemoColor.feedbackAccent
+        includeLogsSwitch.setContentHuggingPriority(.required, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [textStack, includeLogsSwitch])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 12
+        return row
+    }
+
+    // MARK: - Field helpers
+
+    private func configureTextField(_ field: UITextField) {
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.font = .systemFont(ofSize: 15)
+        field.textColor = DemoColor.textPrimary
+        field.borderStyle = .none
+        field.addTarget(self, action: #selector(textChanged), for: .editingChanged)
+    }
+
+    /// Wraps an input view in a rounded, outlined box.
+    private func boxed(_ input: UIView) -> UIView {
+        let box = UIView()
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.backgroundColor = DemoColor.cardBg
+        box.layer.cornerRadius = 10
+        box.layer.cornerCurve = .continuous
+        box.layer.borderColor = DemoColor.cardStroke.cgColor
+        box.layer.borderWidth = 1
+        input.translatesAutoresizingMaskIntoConstraints = false
+        box.addSubview(input)
+        // UITextView carries its own insets; UITextField needs explicit padding.
+        let inset: CGFloat = input is UITextView ? 0 : 11
+        let hInset: CGFloat = input is UITextView ? 0 : 12
+        NSLayoutConstraint.activate([
+            input.topAnchor.constraint(equalTo: box.topAnchor, constant: inset),
+            input.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -inset),
+            input.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: hInset),
+            input.trailingAnchor.constraint(equalTo: box.trailingAnchor, constant: -hInset),
+        ])
+        if !(input is UITextView) {
+            input.heightAnchor.constraint(greaterThanOrEqualToConstant: 22).isActive = true
+        }
+        return box
+    }
+
+    /// A labeled field: a header row (label + red asterisk or "optional") above the input.
+    private func makeField(label: String, required: Bool, input: UIView) -> UIView {
+        let labelView = UILabel()
+        let attributed = NSMutableAttributedString(
+            string: label,
+            attributes: [.font: UIFont.systemFont(ofSize: 14, weight: .semibold),
+                         .foregroundColor: DemoColor.textPrimary])
+        if required {
+            attributed.append(NSAttributedString(
+                string: " *",
+                attributes: [.font: UIFont.systemFont(ofSize: 14, weight: .semibold),
+                             .foregroundColor: DemoColor.asterisk]))
+        }
+        labelView.attributedText = attributed
+
+        let headerRow: UIView
+        if required {
+            headerRow = labelView
+        } else {
+            let optional = UILabel()
+            optional.text = "optional"
+            optional.font = .systemFont(ofSize: 13)
+            optional.textColor = DemoColor.textTertiary
+            let spacer = UIView()
+            spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            let row = UIStackView(arrangedSubviews: [labelView, spacer, optional])
+            row.axis = .horizontal
+            row.alignment = .firstBaseline
+            headerRow = row
+        }
+
+        let stack = UIStackView(arrangedSubviews: [headerRow, input])
+        stack.axis = .vertical
+        stack.spacing = 6
+        stack.alignment = .fill
+        return stack
+    }
+
+    private func makeDivider() -> UIView {
+        let divider = UIView()
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        divider.backgroundColor = DemoColor.cardStroke
+        divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        return divider
+    }
+
+    // MARK: - Actions
+
+    @objc private func categoryChanged() {
+        category = FeedbackCategory.allCases[segmented.selectedSegmentIndex]
+    }
+
+    @objc private func textChanged() {
+        updateSendEnabled()
+    }
+
+    @objc private func closeTapped() {
+        dismiss(animated: true)
+    }
+
+    private func updateSendEnabled() {
+        let hasTitle = !(titleField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let enabled = hasTitle && !isSubmitting
+        sendButton.isEnabled = enabled
+        sendButton.alpha = enabled ? 1.0 : 0.45
+    }
+
+    @objc private func pickFileTapped() {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.delegate = self
+        picker.allowsMultipleSelection = false
+        present(picker, animated: true)
+    }
+
+    private func setSubmitting(_ submitting: Bool) {
+        isSubmitting = submitting
+        if submitting {
+            sendButton.setTitle("", for: .normal)
+            sendSpinner.startAnimating()
+        } else {
+            sendButton.setTitle("Send feedback  →", for: .normal)
+            sendSpinner.stopAnimating()
+        }
+        segmented.isEnabled = !submitting
+        titleField.isEnabled = !submitting
+        descriptionView.isEditable = !submitting
+        nameField.isEnabled = !submitting
+        emailField.isEnabled = !submitting
+        includeLogsSwitch.isEnabled = !submitting
+        attachmentActionButton.isEnabled = !submitting
+        updateSendEnabled()
+    }
+
+    @objc private func submitTapped() {
+        let trimmedTitle = (titleField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+
+        errorLabel.isHidden = true
+        setSubmitting(true)
+
+        var attachments: [BugSplatAttachment] = []
+        if let name = pickedFileName, let data = pickedFileData {
+            let mime = UTType(filenameExtension: (name as NSString).pathExtension)?.preferredMIMEType
+                ?? "application/octet-stream"
+            attachments.append(BugSplatAttachment(filename: name, attachmentData: data, contentType: mime))
+        }
+        if includeLogsSwitch.isOn, let logAttachment = SampleLog.attachment() {
+            attachments.append(logAttachment)
+        }
+
+        let description = descriptionView.text ?? ""
+        let name = nameField.text ?? ""
+        let email = emailField.text ?? ""
+
+        BugSplat.shared().postFeedback(
+            title: trimmedTitle,
+            description: description.isEmpty ? nil : description,
+            userName: name.isEmpty ? nil : name,
+            userEmail: email.isEmpty ? nil : email,
+            appKey: nil,
+            attributes: ["category": category.rawValue],
+            attachments: attachments.isEmpty ? nil : attachments
+        ) { [weak self] result, error in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.setSubmitting(false)
+                if let error = error {
+                    self.errorLabel.text = "Feedback failed: \(error.localizedDescription)"
+                    self.errorLabel.isHidden = false
+                } else {
+                    ActivityLog.record(.feedback, detail: "\u{201C}\(trimmedTitle)\u{201D}")
+                    self.showThanks(result: result)
+                }
+            }
+        }
+    }
+
+    // MARK: - Thank-you screen
+
+    private func buildThanksPlaceholder() {
+        thanksContainer.translatesAutoresizingMaskIntoConstraints = false
+        thanksContainer.backgroundColor = DemoColor.cardBg
+        thanksContainer.isHidden = true
+        view.addSubview(thanksContainer)
+        NSLayoutConstraint.activate([
+            thanksContainer.topAnchor.constraint(equalTo: view.topAnchor),
+            thanksContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            thanksContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            thanksContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func showThanks(result: BugSplatFeedbackResult?) {
+        let reportId = result?.crashId.map { "\($0)" }
+
+        // Check circle
+        let circle = UIView()
+        circle.translatesAutoresizingMaskIntoConstraints = false
+        circle.backgroundColor = DemoColor.feedbackAccent.withAlphaComponent(0.14)
+        circle.layer.cornerRadius = 42
+        circle.layer.borderColor = DemoColor.feedbackAccent.withAlphaComponent(0.35).cgColor
+        circle.layer.borderWidth = 1
+        let check = UIImageView(image: UIImage(systemName: "checkmark",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 32, weight: .bold)))
+        check.tintColor = DemoColor.feedbackAccent
+        check.translatesAutoresizingMaskIntoConstraints = false
+        circle.addSubview(check)
+        NSLayoutConstraint.activate([
+            circle.widthAnchor.constraint(equalToConstant: 84),
+            circle.heightAnchor.constraint(equalToConstant: 84),
+            check.centerXAnchor.constraint(equalTo: circle.centerXAnchor),
+            check.centerYAnchor.constraint(equalTo: circle.centerYAnchor),
+        ])
+        let circleWrap = UIView()
+        circleWrap.addSubview(circle)
+        NSLayoutConstraint.activate([
+            circle.topAnchor.constraint(equalTo: circleWrap.topAnchor),
+            circle.bottomAnchor.constraint(equalTo: circleWrap.bottomAnchor),
+            circle.centerXAnchor.constraint(equalTo: circleWrap.centerXAnchor),
+        ])
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Feedback sent. Thanks!"
+        titleLabel.font = .systemFont(ofSize: 24, weight: .bold)
+        titleLabel.textColor = DemoColor.textPrimary
+        titleLabel.textAlignment = .center
+
+        let messageLabel = UILabel()
+        messageLabel.text = "Your note made it to the BugSplat team. We reply within a day."
+        messageLabel.font = .systemFont(ofSize: 15)
+        messageLabel.textColor = DemoColor.textSecondary
+        messageLabel.textAlignment = .center
+        messageLabel.numberOfLines = 0
+
+        let reportRow = makeReportIdRow(reportId: reportId)
+
+        let topStack = UIStackView(arrangedSubviews: [circleWrap, titleLabel, messageLabel, reportRow])
+        topStack.translatesAutoresizingMaskIntoConstraints = false
+        topStack.axis = .vertical
+        topStack.alignment = .fill
+        topStack.spacing = 16
+        topStack.setCustomSpacing(20, after: messageLabel)
+
+        let footer = makeThanksFooter(result: result)
+
+        thanksContainer.addSubview(topStack)
+        thanksContainer.addSubview(footer)
+        NSLayoutConstraint.activate([
+            topStack.centerYAnchor.constraint(equalTo: thanksContainer.centerYAnchor, constant: -40),
+            topStack.leadingAnchor.constraint(equalTo: thanksContainer.leadingAnchor, constant: 24),
+            topStack.trailingAnchor.constraint(equalTo: thanksContainer.trailingAnchor, constant: -24),
+
+            footer.leadingAnchor.constraint(equalTo: thanksContainer.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: thanksContainer.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: thanksContainer.bottomAnchor),
+        ])
+
+        // Swap form -> thanks with a cross-dissolve.
+        thanksContainer.alpha = 0
+        thanksContainer.isHidden = false
+        UIView.transition(with: view, duration: 0.3, options: .transitionCrossDissolve) {
+            self.formContainer.isHidden = true
+            self.thanksContainer.alpha = 1
+        }
+    }
+
+    private func makeReportIdRow(reportId: String?) -> UIView {
+        let label = UILabel()
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 11, weight: .semibold),
+            .foregroundColor: DemoColor.textTertiary,
+            .kern: 1.1
+        ]
+        label.attributedText = NSAttributedString(string: "REPORT ID", attributes: attrs)
+
+        let idLabel = UILabel()
+        idLabel.text = reportId ?? "Unavailable"
+        idLabel.font = .monospacedSystemFont(ofSize: 15, weight: .medium)
+        idLabel.textColor = DemoColor.textPrimary
+
+        let row = UIStackView(arrangedSubviews: [label, idLabel])
+        row.axis = .horizontal
+        row.spacing = 12
+        row.alignment = .center
+
+        if let reportId = reportId {
+            let copy = UIButton(type: .system)
+            copy.setTitle("Copy", for: .normal)
+            copy.setImage(UIImage(systemName: "doc.on.doc"), for: .normal)
+            copy.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
+            copy.tintColor = DemoColor.textSecondary
+            copy.setTitleColor(DemoColor.textSecondary, for: .normal)
+            copy.backgroundColor = DemoColor.cardBg
+            copy.layer.cornerRadius = 8
+            copy.layer.borderColor = DemoColor.cardStroke.cgColor
+            copy.layer.borderWidth = 1
+            copy.contentEdgeInsets = UIEdgeInsets(top: 7, left: 12, bottom: 7, right: 12)
+            copy.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 0)
+            copy.addAction(UIAction { _ in UIPasteboard.general.string = reportId }, for: .touchUpInside)
+            copy.setContentHuggingPriority(.required, for: .horizontal)
+            let spacer = UIView()
+            spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            row.addArrangedSubview(spacer)
+            row.addArrangedSubview(copy)
+        }
+
+        let card = UIView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.backgroundColor = DemoColor.badgeBg
+        card.layer.cornerRadius = 12
+        card.layer.cornerCurve = .continuous
+        row.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: card.topAnchor, constant: 14),
+            row.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -14),
+            row.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            row.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+        ])
+        return card
+    }
+
+    private func makeThanksFooter(result: BugSplatFeedbackResult?) -> UIView {
+        let dashboard = UIButton(type: .system)
+        dashboard.translatesAutoresizingMaskIntoConstraints = false
+        dashboard.setTitle("View on dashboard  ↗", for: .normal)
+        dashboard.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
+        dashboard.setTitleColor(.white, for: .normal)
+        dashboard.backgroundColor = DemoColor.feedbackAccent
+        dashboard.layer.cornerRadius = 12
+        dashboard.layer.cornerCurve = .continuous
+        dashboard.heightAnchor.constraint(equalToConstant: 52).isActive = true
+        dashboard.addAction(UIAction { [weak self] _ in self?.openReport(result: result) }, for: .touchUpInside)
+
+        let close = UIButton(type: .system)
+        close.setTitle("Close", for: .normal)
+        close.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        close.setTitleColor(DemoColor.textSecondary, for: .normal)
+        close.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+
+        let poweredBy = makePoweredByLabel()
+
+        let stack = UIStackView(arrangedSubviews: [dashboard, close, poweredBy])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 14
+        stack.alignment = .fill
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.layoutMargins = UIEdgeInsets(top: 14, left: 20, bottom: 20, right: 20)
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = DemoColor.footerBg
+        let divider = makeDivider()
+        container.addSubview(divider)
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            divider.topAnchor.constraint(equalTo: container.topAnchor),
+            divider.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.safeAreaLayoutGuide.bottomAnchor),
+        ])
+        return container
+    }
+
+    /// "Powered by BugSplat" where the word BugSplat links to bugsplat.com.
+    private func makePoweredByLabel() -> UIView {
+        let prefix = UILabel()
+        prefix.text = "Powered by"
+        prefix.font = .systemFont(ofSize: 13)
+        prefix.textColor = DemoColor.textTertiary
+
+        let link = UIButton(type: .system)
+        link.setTitle("BugSplat", for: .normal)
+        link.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
+        link.setTitleColor(DemoColor.link, for: .normal)
+        link.contentEdgeInsets = .zero
+        link.addAction(UIAction { _ in
+            if let url = URL(string: "https://bugsplat.com") { UIApplication.shared.open(url) }
+        }, for: .touchUpInside)
+
+        let row = UIStackView(arrangedSubviews: [prefix, link])
+        row.axis = .horizontal
+        row.spacing = 4
+        row.alignment = .center
+
+        let centered = UIStackView(arrangedSubviews: [UIView(), row, UIView()])
+        centered.axis = .horizontal
+        centered.distribution = .equalCentering
+        return centered
+    }
+
+    /// Links directly to the report by id. Feedback reports group by their
+    /// (unique) title, so the SDK's infoUrl resolves to a generic page — prefer
+    /// the id-scoped crash URL, falling back to the database dashboard.
+    private func openReport(result: BugSplatFeedbackResult?) {
+        var components: URLComponents?
+        if let crashId = result?.crashId {
+            components = URLComponents(string: "https://app.bugsplat.com/v2/crash")
+            components?.queryItems = [
+                URLQueryItem(name: "database", value: database),
+                URLQueryItem(name: "id", value: "\(crashId)")
+            ]
+        } else {
+            components = URLComponents(string: "https://app.bugsplat.com/v2/dashboard")
+            components?.queryItems = [URLQueryItem(name: "database", value: database)]
+        }
+        if let url = components?.url {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+// MARK: - Document picker
+
+extension FeedbackViewController: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let url = urls.first else { return }
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        do {
+            pickedFileData = try Data(contentsOf: url)
+            pickedFileName = url.lastPathComponent
+            attachmentNameLabel.textColor = DemoColor.textPrimary
+            renderAttachmentRow()
+        } catch {
+            errorLabel.text = "Couldn't read the selected file: \(error.localizedDescription)"
+            errorLabel.isHidden = false
+        }
+    }
+}

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
@@ -217,12 +217,6 @@ final class FeedbackViewController: UIViewController {
     }
 
     private func makeFormFooter() -> UIView {
-        let hint = UILabel()
-        hint.text = "Triggered by shaking the device."
-        hint.font = .systemFont(ofSize: 13)
-        hint.textColor = DemoColor.textTertiary
-        hint.textAlignment = .center
-
         sendButton.translatesAutoresizingMaskIntoConstraints = false
         sendButton.setTitle("Send feedback  →", for: .normal)
         sendButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .bold)
@@ -242,13 +236,13 @@ final class FeedbackViewController: UIViewController {
             sendSpinner.centerYAnchor.constraint(equalTo: sendButton.centerYAnchor),
         ])
 
-        let stack = UIStackView(arrangedSubviews: [hint, sendButton])
+        let stack = UIStackView(arrangedSubviews: [sendButton])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.spacing = 12
         stack.alignment = .fill
         stack.isLayoutMarginsRelativeArrangement = true
-        stack.layoutMargins = UIEdgeInsets(top: 14, left: 20, bottom: 20, right: 20)
+        stack.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
 
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
@@ -60,6 +60,10 @@ final class FeedbackViewController: UIViewController {
 
     private let formContainer = UIView()
     private let thanksContainer = UIView()
+    private let formScrollView = UIScrollView()
+
+    /// Lifted by the keyboard handler so the footer + scroll view stay above the keyboard.
+    private var layoutBottomConstraint: NSLayoutConstraint!
 
     private let segmented = UISegmentedControl(items: FeedbackCategory.allCases.map { $0.rawValue })
     private let titleField = UITextField()
@@ -86,6 +90,7 @@ final class FeedbackViewController: UIViewController {
         buildThanksPlaceholder()
         renderAttachmentRow()
         updateSendEnabled()
+        installKeyboardHandling()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -113,7 +118,7 @@ final class FeedbackViewController: UIViewController {
         let footer = makeFormFooter()
 
         // Scrollable field content
-        let scrollView = UIScrollView()
+        let scrollView = formScrollView
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.keyboardDismissMode = .interactive
 
@@ -167,11 +172,13 @@ final class FeedbackViewController: UIViewController {
         layout.alignment = .fill
         formContainer.addSubview(layout)
 
+        layoutBottomConstraint = layout.bottomAnchor.constraint(equalTo: formContainer.bottomAnchor)
+
         NSLayoutConstraint.activate([
             layout.topAnchor.constraint(equalTo: formContainer.safeAreaLayoutGuide.topAnchor),
             layout.leadingAnchor.constraint(equalTo: formContainer.leadingAnchor),
             layout.trailingAnchor.constraint(equalTo: formContainer.trailingAnchor),
-            layout.bottomAnchor.constraint(equalTo: formContainer.bottomAnchor),
+            layoutBottomConstraint,
 
             fields.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 20),
             fields.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -20),
@@ -442,6 +449,49 @@ final class FeedbackViewController: UIViewController {
         divider.backgroundColor = DemoColor.cardStroke
         divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
         return divider
+    }
+
+    // MARK: - Keyboard handling
+
+    /// Lifts the form (footer + scroll view) above the keyboard and lets a tap
+    /// outside any field dismiss it.
+    private func installKeyboardHandling() {
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(keyboardFrameWillChange),
+            name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false  // let buttons/controls still receive the tap
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    @objc private func keyboardFrameWillChange(_ note: Notification) {
+        guard let info = note.userInfo,
+              let endFrame = (info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+        else { return }
+        let duration = (info[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
+        let curveRaw = (info[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int) ?? 0
+
+        let endInView = view.convert(endFrame, from: nil)
+        let overlap = max(0, view.bounds.maxY - endInView.minY)
+        layoutBottomConstraint.constant = -overlap
+
+        UIView.animate(withDuration: duration, delay: 0,
+                       options: UIView.AnimationOptions(rawValue: UInt(curveRaw) << 16),
+                       animations: { self.view.layoutIfNeeded() },
+                       completion: { _ in self.scrollActiveFieldToVisible() })
+    }
+
+    /// Keeps the focused field visible after the scroll view shrinks for the keyboard.
+    private func scrollActiveFieldToVisible() {
+        let fields: [UIView] = [titleField, descriptionView, nameField, emailField]
+        guard let active = fields.first(where: { $0.isFirstResponder }) else { return }
+        let rect = formScrollView.convert(active.bounds, from: active)
+        formScrollView.scrollRectToVisible(rect.insetBy(dx: 0, dy: -16), animated: true)
     }
 
     // MARK: - Actions

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/FeedbackViewController.swift
@@ -95,7 +95,11 @@ final class FeedbackViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        onDismiss?()
+        // Only when the sheet is actually going away — not when it is merely
+        // covered by a controller it presented (e.g. the document picker).
+        if isBeingDismissed {
+            onDismiss?()
+        }
     }
 
     // MARK: - Form layout

--- a/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
+++ b/Example_Apps/BugSplatTest-UIKit-Swift/BugSplatTest-UIKit-Swift/ViewController.swift
@@ -13,7 +13,6 @@ final class ViewController: UIViewController {
     // MARK: - State
 
     private var entries: [ActivityEntry] = []
-    private var feedbackStatus: String?
 
     // MARK: - Views
 
@@ -341,7 +340,7 @@ final class ViewController: UIViewController {
     }
 
     private func renderFooter() {
-        footerLabel.text = feedbackStatus ?? "Shake the device to send feedback anytime."
+        footerLabel.text = "Shake the device to send feedback anytime."
     }
 
     // MARK: - Actions
@@ -363,16 +362,17 @@ final class ViewController: UIViewController {
     }
 
     @objc private func presentFeedbackSheet() {
-        let alert = UIAlertController(title: "Send Feedback", message: nil, preferredStyle: .alert)
-        alert.addTextField { $0.placeholder = "Title" }
-        alert.addTextField { $0.placeholder = "Description" }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Send", style: .default) { [weak self, weak alert] _ in
-            let title = alert?.textFields?[0].text ?? ""
-            let description = alert?.textFields?[1].text ?? ""
-            self?.sendFeedback(title: title, description: description)
-        })
-        present(alert, animated: true)
+        // Don't stack a second feedback sheet if one is already showing (e.g. a
+        // shake while the sheet is up).
+        if presentedViewController is FeedbackViewController { return }
+        let feedback = FeedbackViewController()
+        feedback.modalPresentationStyle = .pageSheet
+        feedback.onDismiss = { [weak self] in self?.refreshActivity() }
+        if let sheet = feedback.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(feedback, animated: true)
     }
 
     @objc private func presentHangConfirm() {
@@ -395,34 +395,6 @@ final class ViewController: UIViewController {
         // Single sleep until distantFuture - simpler than a spin loop and keeps
         // the CPU quiet while frozen.
         Thread.sleep(until: .distantFuture)
-    }
-
-    private func sendFeedback(title: String, description: String) {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Treat an empty title the same as Cancel - don't submit, don't record.
-        guard !trimmed.isEmpty else { return }
-        feedbackStatus = "Sending..."
-        renderFooter()
-        BugSplat.shared().postFeedback(
-            title: trimmed,
-            description: description.isEmpty ? nil : description,
-            userName: nil,
-            userEmail: nil,
-            appKey: nil,
-            attachments: nil
-        ) { [weak self] error in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-                if let error = error {
-                    self.feedbackStatus = "Feedback failed: \(error.localizedDescription)"
-                    self.renderFooter()
-                } else {
-                    self.feedbackStatus = "Feedback sent — thank you!"
-                    ActivityLog.record(.feedback, detail: "\u{201C}\(trimmed)\u{201D}")
-                    self.refreshActivity()
-                }
-            }
-        }
     }
 
     @objc private func openDashboard() {

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		65D000AC10010000000000A2 /* BSPActivityLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D000AC10010000000000A1 /* BSPActivityLog.m */; };
 		65D000AC10010000000000B2 /* BSPDemoTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D000AC10010000000000B1 /* BSPDemoTheme.m */; };
 		65D000AC10010000000000C2 /* BSPDemoViews.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D000AC10010000000000C1 /* BSPDemoViews.m */; };
+		FEEDBAC040010000000000C2 /* BSPFeedbackViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEDBAC040010000000000C1 /* BSPFeedbackViewController.m */; };
 		6341B27A2BDC4DEB007EE8AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6341B2792BDC4DEB007EE8AC /* Assets.xcassets */; };
 		6341B27D2BDC4DEB007EE8AC /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6341B27C2BDC4DEB007EE8AC /* Base */; };
 		6341B27F2BDC4DEB007EE8AC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6341B27E2BDC4DEB007EE8AC /* main.m */; };
@@ -45,6 +46,8 @@
 		65D000AC10010000000000B1 /* BSPDemoTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPDemoTheme.m; sourceTree = "<group>"; };
 		65D000AC10010000000000C0 /* BSPDemoViews.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSPDemoViews.h; sourceTree = "<group>"; };
 		65D000AC10010000000000C1 /* BSPDemoViews.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPDemoViews.m; sourceTree = "<group>"; };
+		FEEDBAC040010000000000C0 /* BSPFeedbackViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSPFeedbackViewController.h; sourceTree = "<group>"; };
+		FEEDBAC040010000000000C1 /* BSPFeedbackViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSPFeedbackViewController.m; sourceTree = "<group>"; };
 		6341B2792BDC4DEB007EE8AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6341B27C2BDC4DEB007EE8AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		6341B27E2BDC4DEB007EE8AC /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -96,6 +99,8 @@
 				65D000AC10010000000000B1 /* BSPDemoTheme.m */,
 				65D000AC10010000000000C0 /* BSPDemoViews.h */,
 				65D000AC10010000000000C1 /* BSPDemoViews.m */,
+				FEEDBAC040010000000000C0 /* BSPFeedbackViewController.h */,
+				FEEDBAC040010000000000C1 /* BSPFeedbackViewController.m */,
 				6341B2792BDC4DEB007EE8AC /* Assets.xcassets */,
 				6341B27B2BDC4DEB007EE8AC /* Main.storyboard */,
 				6341B27E2BDC4DEB007EE8AC /* main.m */,
@@ -209,6 +214,7 @@
 				65D000AC10010000000000A2 /* BSPActivityLog.m in Sources */,
 				65D000AC10010000000000B2 /* BSPDemoTheme.m in Sources */,
 				65D000AC10010000000000C2 /* BSPDemoViews.m in Sources */,
+				FEEDBAC040010000000000C2 /* BSPFeedbackViewController.m in Sources */,
 				6341B27F2BDC4DEB007EE8AC /* main.m in Sources */,
 				6341B2752BDC4DE9007EE8AC /* AppDelegate.m in Sources */,
 			);

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPDemoTheme.h
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPDemoTheme.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, readonly) NSColor *activityFeedback;
 @property (class, readonly) NSColor *activityHang;
 
+/// Primary action green used by the feedback sheet (form + thank-you buttons).
+@property (class, readonly) NSColor *feedbackAccent;
+@property (class, readonly) NSColor *footerBg;
+@property (class, readonly) NSColor *asterisk;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPDemoTheme.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPDemoTheme.m
@@ -35,4 +35,8 @@ static NSColor *Hex(uint32_t rgb) {
 + (NSColor *)activityFeedback { return Hex(0x22C55E); }
 + (NSColor *)activityHang     { return Hex(0xE5B142); }
 
++ (NSColor *)feedbackAccent   { return Hex(0x4E9D78); }
++ (NSColor *)footerBg         { return Hex(0xF4F2EA); }
++ (NSColor *)asterisk         { return Hex(0xDC2626); }
+
 @end

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.h
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.h
@@ -1,0 +1,25 @@
+//
+//  BSPFeedbackViewController.h
+//  BugSplatTest-macOS-UIKit-ObjC
+//
+//  The redesigned User Feedback experience: a sheet-presented form for
+//  composing feedback, and a thank-you confirmation shown in the same sheet
+//  after a successful submit. Mirrors the bugsplat-android demo refresh.
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Feedback sheet presented from the demo screen via -presentViewControllerAsSheet:.
+@interface BSPFeedbackViewController : NSViewController
+
+/// Called after the sheet is dismissed so the presenter can refresh state and
+/// clear its feedback-in-progress guard.
+@property (nonatomic, copy, nullable) void (^onDismiss)(void);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.m
@@ -83,7 +83,7 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
 #pragma mark - Lifecycle
 
 - (void)loadView {
-    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, kBSPFeedbackWidth, 640)];
+    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, kBSPFeedbackWidth, 616)];
     root.wantsLayer = YES;
     root.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
     self.view = root;
@@ -91,7 +91,7 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.preferredContentSize = NSMakeSize(kBSPFeedbackWidth, 640);
+    self.preferredContentSize = NSMakeSize(kBSPFeedbackWidth, 616);
     [self buildForm];
     [self renderAttachmentRow];
     [self updateSendEnabled];
@@ -128,18 +128,28 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
     [self addArrangedField:self.segmented to:fields];
 
     self.titleField = [self makeTextField];
-    [fields addArrangedSubview:[self makeFieldWithLabel:@"Title" required:YES input:[self boxedInput:self.titleField height:36]]];
+    [self addArrangedField:[self makeFieldWithLabel:@"Title" required:YES
+                                              input:[self boxedInput:self.titleField height:36]]
+                        to:fields];
 
     NSScrollView *descScroll = [self makeDescriptionScroll];
-    [fields addArrangedSubview:[self makeFieldWithLabel:@"Description" required:NO input:descScroll]];
+    [self addArrangedField:[self makeFieldWithLabel:@"Description" required:NO
+                                              input:[self boxedScroll:descScroll height:84]]
+                        to:fields];
 
     self.nameField = [self makeTextField];
-    [fields addArrangedSubview:[self makeFieldWithLabel:@"Name" required:NO input:[self boxedInput:self.nameField height:36]]];
+    [self addArrangedField:[self makeFieldWithLabel:@"Name" required:NO
+                                              input:[self boxedInput:self.nameField height:36]]
+                        to:fields];
 
     self.emailField = [self makeTextField];
-    [fields addArrangedSubview:[self makeFieldWithLabel:@"Email" required:NO input:[self boxedInput:self.emailField height:36]]];
+    [self addArrangedField:[self makeFieldWithLabel:@"Email" required:NO
+                                              input:[self boxedInput:self.emailField height:36]]
+                        to:fields];
 
-    [fields addArrangedSubview:[self makeFieldWithLabel:@"Attachment" required:NO input:[self makeAttachmentRow]]];
+    [self addArrangedField:[self makeFieldWithLabel:@"Attachment" required:NO
+                                              input:[self makeAttachmentRow]]
+                        to:fields];
 
     [self addArrangedField:[self makeIncludeLogsRow] to:fields];
 
@@ -211,11 +221,6 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
 }
 
 - (NSView *)makeFormFooter {
-    NSTextField *hint = [NSTextField labelWithString:@"Press any 6 keys at once to send feedback."];
-    hint.font = [NSFont systemFontOfSize:12];
-    hint.textColor = [BSPDemoTheme textTertiary];
-    hint.alignment = NSTextAlignmentCenter;
-
     self.sendButton = [NSButton buttonWithTitle:@"Send feedback  →" target:self action:@selector(submitTapped)];
     self.sendButton.translatesAutoresizingMaskIntoConstraints = NO;
     self.sendButton.bezelStyle = NSBezelStyleRounded;
@@ -235,12 +240,12 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
         [self.sendSpinner.centerYAnchor constraintEqualToAnchor:self.sendButton.centerYAnchor],
     ]];
 
-    NSStackView *stack = [NSStackView stackViewWithViews:@[ hint, self.sendButton ]];
+    NSStackView *stack = [NSStackView stackViewWithViews:@[ self.sendButton ]];
     stack.translatesAutoresizingMaskIntoConstraints = NO;
     stack.orientation = NSUserInterfaceLayoutOrientationVertical;
     stack.alignment = NSLayoutAttributeCenterX;
     stack.spacing = 10;
-    stack.edgeInsets = NSEdgeInsetsMake(14, 20, 20, 20);
+    stack.edgeInsets = NSEdgeInsetsMake(16, 20, 20, 20);
 
     return [self footerContainerWithContent:stack stretchView:self.sendButton];
 }
@@ -275,20 +280,21 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
     scroll.hasVerticalScroller = YES;
     scroll.borderType = NSNoBorder;
     scroll.drawsBackground = NO;
-    scroll.wantsLayer = YES;
-    scroll.layer.cornerRadius = 8;
-    scroll.layer.borderWidth = 1;
-    scroll.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
-    [scroll.heightAnchor constraintEqualToConstant:84].active = YES;
 
     self.descriptionView = [[NSTextView alloc] initWithFrame:NSZeroRect];
     self.descriptionView.font = [NSFont systemFontOfSize:13];
     self.descriptionView.textColor = [BSPDemoTheme textPrimary];
-    self.descriptionView.drawsBackground = YES;
-    self.descriptionView.backgroundColor = [BSPDemoTheme cardBg];
+    self.descriptionView.drawsBackground = NO;
     self.descriptionView.textContainerInset = NSMakeSize(6, 7);
     self.descriptionView.richText = NO;
     self.descriptionView.automaticQuoteSubstitutionEnabled = NO;
+    // Standard text-view-in-scroll-view sizing so typed text wraps to the box.
+    self.descriptionView.autoresizingMask = NSViewWidthSizable;
+    self.descriptionView.minSize = NSMakeSize(0, 0);
+    self.descriptionView.maxSize = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
+    self.descriptionView.verticallyResizable = YES;
+    self.descriptionView.horizontallyResizable = NO;
+    self.descriptionView.textContainer.widthTracksTextView = YES;
     scroll.documentView = self.descriptionView;
     return scroll;
 }
@@ -435,6 +441,28 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
     return box;
 }
 
+/// Wraps a scroll view in a rounded, outlined box. The box (a plain NSView)
+/// draws the border — a border set on the scroll view's own layer is not
+/// rendered reliably by AppKit.
+- (NSView *)boxedScroll:(NSScrollView *)scroll height:(CGFloat)height {
+    NSView *box = [NSView new];
+    box.translatesAutoresizingMaskIntoConstraints = NO;
+    box.wantsLayer = YES;
+    box.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
+    box.layer.cornerRadius = 8;
+    box.layer.borderWidth = 1;
+    box.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+    [box addSubview:scroll];
+    [NSLayoutConstraint activateConstraints:@[
+        [box.heightAnchor constraintEqualToConstant:height],
+        [scroll.topAnchor constraintEqualToAnchor:box.topAnchor constant:1],
+        [scroll.bottomAnchor constraintEqualToAnchor:box.bottomAnchor constant:-1],
+        [scroll.leadingAnchor constraintEqualToAnchor:box.leadingAnchor constant:1],
+        [scroll.trailingAnchor constraintEqualToAnchor:box.trailingAnchor constant:-1],
+    ]];
+    return box;
+}
+
 /// A labeled field: a header row (label + red asterisk or "optional") above the input.
 - (NSView *)makeFieldWithLabel:(NSString *)label required:(BOOL)required input:(NSView *)input {
     NSMutableAttributedString *attributed = [[NSMutableAttributedString alloc]
@@ -508,7 +536,15 @@ static CGFloat const kBSPFeedbackWidth = 480.0;
 }
 
 - (void)closeTapped {
-    [self dismissViewController:self];
+    // Dismiss via the presenter so its -presentedViewControllers is properly
+    // cleared — otherwise the presenter's "already showing?" guard keeps the
+    // feedback sheet from being opened again.
+    NSViewController *presenter = self.presentingViewController;
+    if (presenter) {
+        [presenter dismissViewController:self];
+    } else {
+        [self dismissViewController:self];
+    }
 }
 
 - (void)updateSendEnabled {

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/BSPFeedbackViewController.m
@@ -1,0 +1,821 @@
+//
+//  BSPFeedbackViewController.m
+//  BugSplatTest-macOS-UIKit-ObjC
+//
+//  Copyright © BugSplat, LLC. All rights reserved.
+//
+
+#import "BSPFeedbackViewController.h"
+#import "BSPDemoTheme.h"
+#import "BSPActivityLog.h"
+#import <BugSplat/BugSplat.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+static CGFloat const kBSPFeedbackWidth = 480.0;
+
+#pragma mark - Sample log helper
+
+/// Locates the `sample_log.txt` file the app writes at launch (see AppDelegate)
+/// so it can be attached to feedback when the user opts in.
+@interface BSPSampleLog : NSObject
++ (nullable BugSplatAttachment *)attachment;
+@end
+
+@implementation BSPSampleLog
+
++ (BugSplatAttachment *)attachment {
+    NSURL *docs = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                          inDomains:NSUserDomainMask] firstObject];
+    NSURL *url = [docs URLByAppendingPathComponent:@"sample_log.txt"];
+    NSData *data = url ? [NSData dataWithContentsOfURL:url] : nil;
+    if (!data) return nil;
+    return [[BugSplatAttachment alloc] initWithFilename:@"sample_log.txt"
+                                         attachmentData:data
+                                            contentType:@"text/plain"];
+}
+
+@end
+
+#pragma mark - Feedback view controller
+
+@interface BSPFeedbackViewController () <NSTextFieldDelegate>
+
+@property (nonatomic, strong) NSView *formContainer;
+@property (nonatomic, strong) NSView *thanksContainer;
+
+@property (nonatomic, strong) NSSegmentedControl *segmented;
+@property (nonatomic, strong) NSTextField *titleField;
+@property (nonatomic, strong) NSTextView *descriptionView;
+@property (nonatomic, strong) NSTextField *nameField;
+@property (nonatomic, strong) NSTextField *emailField;
+@property (nonatomic, strong) NSButton *includeLogsSwitch;
+@property (nonatomic, strong) NSTextField *errorLabel;
+@property (nonatomic, strong) NSButton *sendButton;
+@property (nonatomic, strong) NSProgressIndicator *sendSpinner;
+
+@property (nonatomic, strong) NSTextField *attachmentTypeChip;
+@property (nonatomic, strong) NSTextField *attachmentNameLabel;
+@property (nonatomic, strong) NSTextField *attachmentDetailLabel;
+@property (nonatomic, strong) NSButton *attachmentActionButton;
+
+@property (nonatomic, copy, nullable) NSString *pickedFileName;
+@property (nonatomic, strong, nullable) NSData *pickedFileData;
+@property (nonatomic, assign) BOOL submitting;
+
+/// The submitted feedback result, retained so the thank-you actions can use it.
+@property (nonatomic, strong, nullable) BugSplatFeedbackResult *thanksResult;
+
+@end
+
+@implementation BSPFeedbackViewController
+
+- (NSString *)database {
+    return [BugSplat shared].bugSplatDatabase ?: @"—";
+}
+
+- (NSString *)selectedCategory {
+    NSArray<NSString *> *categories = @[ @"Bug", @"Feature", @"Other" ];
+    NSInteger index = self.segmented.selectedSegment;
+    if (index < 0 || index >= (NSInteger)categories.count) return @"Bug";
+    return categories[index];
+}
+
+#pragma mark - Lifecycle
+
+- (void)loadView {
+    NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, kBSPFeedbackWidth, 640)];
+    root.wantsLayer = YES;
+    root.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
+    self.view = root;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.preferredContentSize = NSMakeSize(kBSPFeedbackWidth, 640);
+    [self buildForm];
+    [self renderAttachmentRow];
+    [self updateSendEnabled];
+}
+
+- (void)viewDidDisappear {
+    [super viewDidDisappear];
+    if (self.onDismiss) self.onDismiss();
+}
+
+#pragma mark - Form layout
+
+- (void)buildForm {
+    self.formContainer = [NSView new];
+    self.formContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.formContainer];
+    [self pinView:self.formContainer toEdgesOf:self.view];
+
+    NSView *header = [self makeHeaderWithTitle:@"Send feedback"];
+    NSView *headerDivider = [self makeDivider];
+    NSView *footer = [self makeFormFooter];
+
+    NSStackView *fields = [NSStackView new];
+    fields.translatesAutoresizingMaskIntoConstraints = NO;
+    fields.orientation = NSUserInterfaceLayoutOrientationVertical;
+    fields.alignment = NSLayoutAttributeLeading;
+    fields.spacing = 16;
+
+    self.segmented = [NSSegmentedControl segmentedControlWithLabels:@[ @"Bug", @"Feature", @"Other" ]
+                                                       trackingMode:NSSegmentSwitchTrackingSelectOne
+                                                             target:nil
+                                                             action:nil];
+    self.segmented.selectedSegment = 0;
+    [self addArrangedField:self.segmented to:fields];
+
+    self.titleField = [self makeTextField];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Title" required:YES input:[self boxedInput:self.titleField height:36]]];
+
+    NSScrollView *descScroll = [self makeDescriptionScroll];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Description" required:NO input:descScroll]];
+
+    self.nameField = [self makeTextField];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Name" required:NO input:[self boxedInput:self.nameField height:36]]];
+
+    self.emailField = [self makeTextField];
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Email" required:NO input:[self boxedInput:self.emailField height:36]]];
+
+    [fields addArrangedSubview:[self makeFieldWithLabel:@"Attachment" required:NO input:[self makeAttachmentRow]]];
+
+    [self addArrangedField:[self makeIncludeLogsRow] to:fields];
+
+    self.errorLabel = [self plainLabel:@"" size:12 color:[BSPDemoTheme asterisk]];
+    self.errorLabel.hidden = YES;
+    [self addArrangedField:self.errorLabel to:fields];
+
+    NSStackView *layout = [NSStackView stackViewWithViews:@[ header, headerDivider, fields, footer ]];
+    layout.translatesAutoresizingMaskIntoConstraints = NO;
+    layout.orientation = NSUserInterfaceLayoutOrientationVertical;
+    layout.alignment = NSLayoutAttributeLeading;
+    layout.spacing = 0;
+    [layout setCustomSpacing:18 afterView:headerDivider];
+    [layout setCustomSpacing:18 afterView:fields];
+    [self.formContainer addSubview:layout];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [layout.topAnchor constraintEqualToAnchor:self.formContainer.topAnchor],
+        [layout.leadingAnchor constraintEqualToAnchor:self.formContainer.leadingAnchor],
+        [layout.trailingAnchor constraintEqualToAnchor:self.formContainer.trailingAnchor],
+        [layout.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor],
+
+        [header.leadingAnchor constraintEqualToAnchor:layout.leadingAnchor],
+        [header.trailingAnchor constraintEqualToAnchor:layout.trailingAnchor],
+        [headerDivider.leadingAnchor constraintEqualToAnchor:layout.leadingAnchor],
+        [headerDivider.trailingAnchor constraintEqualToAnchor:layout.trailingAnchor],
+        [footer.leadingAnchor constraintEqualToAnchor:layout.leadingAnchor],
+        [footer.trailingAnchor constraintEqualToAnchor:layout.trailingAnchor],
+        [fields.leadingAnchor constraintEqualToAnchor:layout.leadingAnchor constant:20],
+        [fields.trailingAnchor constraintEqualToAnchor:layout.trailingAnchor constant:-20],
+        [fields.topAnchor constraintEqualToAnchor:headerDivider.bottomAnchor constant:18],
+    ]];
+}
+
+/// Add a field row that should stretch to the full content width.
+- (void)addArrangedField:(NSView *)field to:(NSStackView *)stack {
+    [stack addArrangedSubview:field];
+    [field.leadingAnchor constraintEqualToAnchor:stack.leadingAnchor].active = YES;
+    [field.trailingAnchor constraintEqualToAnchor:stack.trailingAnchor].active = YES;
+}
+
+- (NSView *)makeHeaderWithTitle:(NSString *)title {
+    NSTextField *label = [NSTextField labelWithString:title];
+    label.font = [NSFont systemFontOfSize:20 weight:NSFontWeightBold];
+    label.textColor = [BSPDemoTheme textPrimary];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSButton *close = [NSButton buttonWithImage:[NSImage imageWithSystemSymbolName:@"xmark"
+                                                         accessibilityDescription:@"Close"]
+                                         target:self
+                                         action:@selector(closeTapped)];
+    close.translatesAutoresizingMaskIntoConstraints = NO;
+    close.bordered = NO;
+    close.contentTintColor = [BSPDemoTheme textSecondary];
+
+    NSView *bar = [NSView new];
+    bar.translatesAutoresizingMaskIntoConstraints = NO;
+    [bar addSubview:label];
+    [bar addSubview:close];
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:bar.leadingAnchor constant:20],
+        [label.centerYAnchor constraintEqualToAnchor:bar.centerYAnchor],
+        [label.topAnchor constraintEqualToAnchor:bar.topAnchor constant:16],
+        [label.bottomAnchor constraintEqualToAnchor:bar.bottomAnchor constant:-16],
+        [close.trailingAnchor constraintEqualToAnchor:bar.trailingAnchor constant:-20],
+        [close.centerYAnchor constraintEqualToAnchor:bar.centerYAnchor],
+    ]];
+    return bar;
+}
+
+- (NSView *)makeFormFooter {
+    NSTextField *hint = [NSTextField labelWithString:@"Press any 6 keys at once to send feedback."];
+    hint.font = [NSFont systemFontOfSize:12];
+    hint.textColor = [BSPDemoTheme textTertiary];
+    hint.alignment = NSTextAlignmentCenter;
+
+    self.sendButton = [NSButton buttonWithTitle:@"Send feedback  →" target:self action:@selector(submitTapped)];
+    self.sendButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.sendButton.bezelStyle = NSBezelStyleRounded;
+    self.sendButton.keyEquivalent = @"\r";
+    self.sendButton.controlSize = NSControlSizeLarge;
+    self.sendButton.bezelColor = [BSPDemoTheme feedbackAccent];
+    [self.sendButton.heightAnchor constraintEqualToConstant:36].active = YES;
+
+    self.sendSpinner = [NSProgressIndicator new];
+    self.sendSpinner.translatesAutoresizingMaskIntoConstraints = NO;
+    self.sendSpinner.style = NSProgressIndicatorStyleSpinning;
+    self.sendSpinner.controlSize = NSControlSizeSmall;
+    self.sendSpinner.displayedWhenStopped = NO;
+    [self.sendButton addSubview:self.sendSpinner];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.sendSpinner.centerXAnchor constraintEqualToAnchor:self.sendButton.centerXAnchor],
+        [self.sendSpinner.centerYAnchor constraintEqualToAnchor:self.sendButton.centerYAnchor],
+    ]];
+
+    NSStackView *stack = [NSStackView stackViewWithViews:@[ hint, self.sendButton ]];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    stack.alignment = NSLayoutAttributeCenterX;
+    stack.spacing = 10;
+    stack.edgeInsets = NSEdgeInsetsMake(14, 20, 20, 20);
+
+    return [self footerContainerWithContent:stack stretchView:self.sendButton];
+}
+
+- (NSView *)footerContainerWithContent:(NSStackView *)content stretchView:(nullable NSView *)stretch {
+    NSView *container = [NSView new];
+    container.translatesAutoresizingMaskIntoConstraints = NO;
+    container.wantsLayer = YES;
+    container.layer.backgroundColor = [BSPDemoTheme footerBg].CGColor;
+    NSView *divider = [self makeDivider];
+    [container addSubview:divider];
+    [container addSubview:content];
+    [NSLayoutConstraint activateConstraints:@[
+        [divider.topAnchor constraintEqualToAnchor:container.topAnchor],
+        [divider.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+        [divider.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+        [content.topAnchor constraintEqualToAnchor:container.topAnchor],
+        [content.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+        [content.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+        [content.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+    ]];
+    if (stretch) {
+        [stretch.leadingAnchor constraintEqualToAnchor:content.leadingAnchor constant:20].active = YES;
+        [stretch.trailingAnchor constraintEqualToAnchor:content.trailingAnchor constant:-20].active = YES;
+    }
+    return container;
+}
+
+- (NSScrollView *)makeDescriptionScroll {
+    NSScrollView *scroll = [NSScrollView new];
+    scroll.translatesAutoresizingMaskIntoConstraints = NO;
+    scroll.hasVerticalScroller = YES;
+    scroll.borderType = NSNoBorder;
+    scroll.drawsBackground = NO;
+    scroll.wantsLayer = YES;
+    scroll.layer.cornerRadius = 8;
+    scroll.layer.borderWidth = 1;
+    scroll.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+    [scroll.heightAnchor constraintEqualToConstant:84].active = YES;
+
+    self.descriptionView = [[NSTextView alloc] initWithFrame:NSZeroRect];
+    self.descriptionView.font = [NSFont systemFontOfSize:13];
+    self.descriptionView.textColor = [BSPDemoTheme textPrimary];
+    self.descriptionView.drawsBackground = YES;
+    self.descriptionView.backgroundColor = [BSPDemoTheme cardBg];
+    self.descriptionView.textContainerInset = NSMakeSize(6, 7);
+    self.descriptionView.richText = NO;
+    self.descriptionView.automaticQuoteSubstitutionEnabled = NO;
+    scroll.documentView = self.descriptionView;
+    return scroll;
+}
+
+- (NSView *)makeAttachmentRow {
+    NSView *row = [NSView new];
+    row.translatesAutoresizingMaskIntoConstraints = NO;
+    row.wantsLayer = YES;
+    row.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
+    row.layer.cornerRadius = 8;
+    row.layer.borderWidth = 1;
+    row.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+
+    self.attachmentTypeChip = [NSTextField labelWithString:@""];
+    self.attachmentTypeChip.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentTypeChip.font = [NSFont systemFontOfSize:10 weight:NSFontWeightSemibold];
+    self.attachmentTypeChip.textColor = [BSPDemoTheme textSecondary];
+    self.attachmentTypeChip.alignment = NSTextAlignmentCenter;
+    self.attachmentTypeChip.wantsLayer = YES;
+    self.attachmentTypeChip.layer.backgroundColor = [BSPDemoTheme badgeBg].CGColor;
+    self.attachmentTypeChip.layer.cornerRadius = 6;
+
+    self.attachmentNameLabel = [NSTextField labelWithString:@""];
+    self.attachmentNameLabel.font = [NSFont systemFontOfSize:13 weight:NSFontWeightMedium];
+    self.attachmentNameLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+
+    self.attachmentDetailLabel = [NSTextField labelWithString:@""];
+    self.attachmentDetailLabel.font = [NSFont systemFontOfSize:11];
+    self.attachmentDetailLabel.textColor = [BSPDemoTheme textTertiary];
+
+    NSStackView *textStack = [NSStackView stackViewWithViews:@[ self.attachmentNameLabel, self.attachmentDetailLabel ]];
+    textStack.translatesAutoresizingMaskIntoConstraints = NO;
+    textStack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    textStack.alignment = NSLayoutAttributeLeading;
+    textStack.spacing = 2;
+
+    self.attachmentActionButton = [NSButton buttonWithTitle:@"Add" target:self action:@selector(pickFileTapped)];
+    self.attachmentActionButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.attachmentActionButton.bordered = NO;
+    self.attachmentActionButton.contentTintColor = [BSPDemoTheme link];
+    self.attachmentActionButton.font = [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold];
+
+    [row addSubview:self.attachmentTypeChip];
+    [row addSubview:textStack];
+    [row addSubview:self.attachmentActionButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [row.heightAnchor constraintEqualToConstant:60],
+        [self.attachmentTypeChip.leadingAnchor constraintEqualToAnchor:row.leadingAnchor constant:12],
+        [self.attachmentTypeChip.centerYAnchor constraintEqualToAnchor:row.centerYAnchor],
+        [self.attachmentTypeChip.widthAnchor constraintEqualToConstant:40],
+        [self.attachmentTypeChip.heightAnchor constraintEqualToConstant:40],
+
+        [textStack.leadingAnchor constraintEqualToAnchor:self.attachmentTypeChip.trailingAnchor constant:12],
+        [textStack.centerYAnchor constraintEqualToAnchor:row.centerYAnchor],
+
+        [self.attachmentActionButton.leadingAnchor constraintGreaterThanOrEqualToAnchor:textStack.trailingAnchor constant:8],
+        [self.attachmentActionButton.trailingAnchor constraintEqualToAnchor:row.trailingAnchor constant:-12],
+        [self.attachmentActionButton.centerYAnchor constraintEqualToAnchor:row.centerYAnchor],
+    ]];
+    return row;
+}
+
+- (void)renderAttachmentRow {
+    if (self.pickedFileName.length > 0 && self.pickedFileData) {
+        NSString *ext = self.pickedFileName.pathExtension.uppercaseString;
+        self.attachmentTypeChip.stringValue = ext.length > 0 ? ext : @"FILE";
+        self.attachmentTypeChip.hidden = NO;
+        self.attachmentNameLabel.stringValue = self.pickedFileName;
+        self.attachmentNameLabel.textColor = [BSPDemoTheme textPrimary];
+        self.attachmentDetailLabel.stringValue =
+            [NSByteCountFormatter stringFromByteCount:(long long)self.pickedFileData.length
+                                           countStyle:NSByteCountFormatterCountStyleFile];
+        self.attachmentDetailLabel.hidden = NO;
+        self.attachmentActionButton.title = @"Replace";
+    } else {
+        self.attachmentTypeChip.hidden = YES;
+        self.attachmentNameLabel.stringValue = @"No file selected";
+        self.attachmentNameLabel.textColor = [BSPDemoTheme textTertiary];
+        self.attachmentDetailLabel.hidden = YES;
+        self.attachmentActionButton.title = @"Add";
+    }
+}
+
+- (NSView *)makeIncludeLogsRow {
+    NSTextField *title = [NSTextField labelWithString:@"Include logs"];
+    title.font = [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold];
+    title.textColor = [BSPDemoTheme textPrimary];
+
+    NSTextField *subtitle = [NSTextField labelWithString:@"Attach the app's sample_log.txt"];
+    subtitle.font = [NSFont systemFontOfSize:11];
+    subtitle.textColor = [BSPDemoTheme textTertiary];
+
+    NSStackView *textStack = [NSStackView stackViewWithViews:@[ title, subtitle ]];
+    textStack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    textStack.alignment = NSLayoutAttributeLeading;
+    textStack.spacing = 2;
+
+    self.includeLogsSwitch = [NSButton new];
+    self.includeLogsSwitch.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.includeLogsSwitch setButtonType:NSButtonTypeSwitch];
+    self.includeLogsSwitch.title = @"";
+    self.includeLogsSwitch.state = NSControlStateValueOn;
+
+    NSView *spacer = [NSView new];
+    NSStackView *row = [NSStackView stackViewWithViews:@[ textStack, spacer, self.includeLogsSwitch ]];
+    row.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+    row.alignment = NSLayoutAttributeCenterY;
+    row.spacing = 12;
+    [row setHuggingPriority:NSLayoutPriorityDefaultLow forOrientation:NSLayoutConstraintOrientationHorizontal];
+    return row;
+}
+
+#pragma mark - Field helpers
+
+- (NSTextField *)makeTextField {
+    NSTextField *field = [NSTextField new];
+    field.translatesAutoresizingMaskIntoConstraints = NO;
+    field.font = [NSFont systemFontOfSize:13];
+    field.textColor = [BSPDemoTheme textPrimary];
+    field.bordered = NO;
+    field.bezeled = NO;
+    field.drawsBackground = NO;
+    field.focusRingType = NSFocusRingTypeNone;
+    field.delegate = self;
+    return field;
+}
+
+/// Wraps an input control in a rounded, outlined box.
+- (NSView *)boxedInput:(NSView *)input height:(CGFloat)height {
+    NSView *box = [NSView new];
+    box.translatesAutoresizingMaskIntoConstraints = NO;
+    box.wantsLayer = YES;
+    box.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
+    box.layer.cornerRadius = 8;
+    box.layer.borderWidth = 1;
+    box.layer.borderColor = [BSPDemoTheme cardStroke].CGColor;
+    [box addSubview:input];
+    [NSLayoutConstraint activateConstraints:@[
+        [box.heightAnchor constraintEqualToConstant:height],
+        [input.leadingAnchor constraintEqualToAnchor:box.leadingAnchor constant:10],
+        [input.trailingAnchor constraintEqualToAnchor:box.trailingAnchor constant:-10],
+        [input.centerYAnchor constraintEqualToAnchor:box.centerYAnchor],
+    ]];
+    return box;
+}
+
+/// A labeled field: a header row (label + red asterisk or "optional") above the input.
+- (NSView *)makeFieldWithLabel:(NSString *)label required:(BOOL)required input:(NSView *)input {
+    NSMutableAttributedString *attributed = [[NSMutableAttributedString alloc]
+        initWithString:label
+            attributes:@{ NSFontAttributeName: [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold],
+                          NSForegroundColorAttributeName: [BSPDemoTheme textPrimary] }];
+    if (required) {
+        [attributed appendAttributedString:[[NSAttributedString alloc]
+            initWithString:@" *"
+                attributes:@{ NSFontAttributeName: [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold],
+                              NSForegroundColorAttributeName: [BSPDemoTheme asterisk] }]];
+    }
+    NSTextField *labelView = [NSTextField labelWithAttributedString:attributed];
+
+    NSView *headerRow;
+    if (required) {
+        headerRow = labelView;
+    } else {
+        NSTextField *optional = [NSTextField labelWithString:@"optional"];
+        optional.font = [NSFont systemFontOfSize:12];
+        optional.textColor = [BSPDemoTheme textTertiary];
+        NSView *spacer = [NSView new];
+        NSStackView *row = [NSStackView stackViewWithViews:@[ labelView, spacer, optional ]];
+        row.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+        row.spacing = 6;
+        headerRow = row;
+    }
+
+    NSStackView *stack = [NSStackView stackViewWithViews:@[ headerRow, input ]];
+    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    stack.alignment = NSLayoutAttributeLeading;
+    stack.spacing = 6;
+    [headerRow.leadingAnchor constraintEqualToAnchor:stack.leadingAnchor].active = YES;
+    [headerRow.trailingAnchor constraintEqualToAnchor:stack.trailingAnchor].active = YES;
+    [input.leadingAnchor constraintEqualToAnchor:stack.leadingAnchor].active = YES;
+    [input.trailingAnchor constraintEqualToAnchor:stack.trailingAnchor].active = YES;
+    return stack;
+}
+
+- (NSTextField *)plainLabel:(NSString *)text size:(CGFloat)size color:(NSColor *)color {
+    NSTextField *label = [NSTextField wrappingLabelWithString:text];
+    label.font = [NSFont systemFontOfSize:size];
+    label.textColor = color;
+    label.selectable = NO;
+    return label;
+}
+
+- (NSView *)makeDivider {
+    NSView *divider = [NSView new];
+    divider.translatesAutoresizingMaskIntoConstraints = NO;
+    divider.wantsLayer = YES;
+    divider.layer.backgroundColor = [BSPDemoTheme cardStroke].CGColor;
+    [divider.heightAnchor constraintEqualToConstant:1].active = YES;
+    return divider;
+}
+
+- (void)pinView:(NSView *)view toEdgesOf:(NSView *)container {
+    [NSLayoutConstraint activateConstraints:@[
+        [view.topAnchor constraintEqualToAnchor:container.topAnchor],
+        [view.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+        [view.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+        [view.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+    ]];
+}
+
+#pragma mark - Form actions
+
+/// NSTextFieldDelegate — re-evaluate the Send button as the title is typed.
+- (void)controlTextDidChange:(NSNotification *)notification {
+    [self updateSendEnabled];
+}
+
+- (void)closeTapped {
+    [self dismissViewController:self];
+}
+
+- (void)updateSendEnabled {
+    NSString *trimmed = [self.titleField.stringValue
+                         stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    self.sendButton.enabled = trimmed.length > 0 && !self.submitting;
+}
+
+- (void)pickFileTapped {
+    NSOpenPanel *panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = YES;
+    panel.canChooseDirectories = NO;
+    panel.allowsMultipleSelection = NO;
+    __weak typeof(self) weakSelf = self;
+    [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSModalResponse result) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf || result != NSModalResponseOK) return;
+        NSURL *url = panel.URL;
+        NSError *error = nil;
+        NSData *data = url ? [NSData dataWithContentsOfURL:url options:0 error:&error] : nil;
+        if (data) {
+            strongSelf.pickedFileData = data;
+            strongSelf.pickedFileName = url.lastPathComponent;
+            [strongSelf renderAttachmentRow];
+        } else {
+            strongSelf.errorLabel.stringValue =
+                [NSString stringWithFormat:@"Couldn't read the selected file: %@", error.localizedDescription];
+            strongSelf.errorLabel.hidden = NO;
+        }
+    }];
+}
+
+- (void)setSubmitting:(BOOL)submitting {
+    _submitting = submitting;
+    if (submitting) {
+        self.sendButton.title = @"";
+        [self.sendSpinner startAnimation:nil];
+    } else {
+        self.sendButton.title = @"Send feedback  →";
+        [self.sendSpinner stopAnimation:nil];
+    }
+    self.segmented.enabled = !submitting;
+    self.titleField.enabled = !submitting;
+    self.descriptionView.editable = !submitting;
+    self.nameField.enabled = !submitting;
+    self.emailField.enabled = !submitting;
+    self.includeLogsSwitch.enabled = !submitting;
+    self.attachmentActionButton.enabled = !submitting;
+    [self updateSendEnabled];
+}
+
+- (void)submitTapped {
+    NSString *trimmedTitle = [self.titleField.stringValue
+                              stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmedTitle.length == 0) return;
+
+    self.errorLabel.hidden = YES;
+    [self setSubmitting:YES];
+
+    NSMutableArray<BugSplatAttachment *> *attachments = [NSMutableArray array];
+    if (self.pickedFileName.length > 0 && self.pickedFileData) {
+        UTType *type = [UTType typeWithFilenameExtension:self.pickedFileName.pathExtension];
+        NSString *mime = type.preferredMIMEType ?: @"application/octet-stream";
+        [attachments addObject:[[BugSplatAttachment alloc] initWithFilename:self.pickedFileName
+                                                             attachmentData:self.pickedFileData
+                                                                contentType:mime]];
+    }
+    if (self.includeLogsSwitch.state == NSControlStateValueOn) {
+        BugSplatAttachment *log = [BSPSampleLog attachment];
+        if (log) [attachments addObject:log];
+    }
+
+    NSString *descText = self.descriptionView.string;
+    NSString *name = self.nameField.stringValue;
+    NSString *email = self.emailField.stringValue;
+
+    __weak typeof(self) weakSelf = self;
+    [[BugSplat shared] postFeedback:trimmedTitle
+                        description:descText.length > 0 ? descText : nil
+                           userName:name.length > 0 ? name : nil
+                          userEmail:email.length > 0 ? email : nil
+                             appKey:nil
+                         attributes:@{ @"category": [self selectedCategory] }
+                        attachments:attachments.count > 0 ? attachments : nil
+                         completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            [strongSelf setSubmitting:NO];
+            if (error) {
+                strongSelf.errorLabel.stringValue =
+                    [NSString stringWithFormat:@"Feedback failed: %@", error.localizedDescription];
+                strongSelf.errorLabel.hidden = NO;
+            } else {
+                NSString *detail = [NSString stringWithFormat:@"“%@”", trimmedTitle];
+                [BSPActivityLog record:BSPActivityTypeFeedback detail:detail];
+                [strongSelf showThanksWithResult:result];
+            }
+        });
+    }];
+}
+
+#pragma mark - Thank-you screen
+
+- (void)showThanksWithResult:(BugSplatFeedbackResult *)result {
+    NSString *reportId = result.crashId ? result.crashId.stringValue : nil;
+
+    self.thanksContainer = [NSView new];
+    self.thanksContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    self.thanksContainer.wantsLayer = YES;
+    self.thanksContainer.layer.backgroundColor = [BSPDemoTheme cardBg].CGColor;
+    [self.view addSubview:self.thanksContainer];
+    [self pinView:self.thanksContainer toEdgesOf:self.view];
+
+    // Check circle
+    NSView *circle = [NSView new];
+    circle.translatesAutoresizingMaskIntoConstraints = NO;
+    circle.wantsLayer = YES;
+    circle.layer.backgroundColor = [[BSPDemoTheme feedbackAccent] colorWithAlphaComponent:0.14].CGColor;
+    circle.layer.cornerRadius = 40;
+    circle.layer.borderWidth = 1;
+    circle.layer.borderColor = [[BSPDemoTheme feedbackAccent] colorWithAlphaComponent:0.35].CGColor;
+    NSImageSymbolConfiguration *checkConfig = [NSImageSymbolConfiguration configurationWithPointSize:30
+                                                                                              weight:NSFontWeightBold];
+    NSImage *checkImage = [[NSImage imageWithSystemSymbolName:@"checkmark" accessibilityDescription:nil]
+                           imageWithSymbolConfiguration:checkConfig];
+    NSImageView *check = [NSImageView imageViewWithImage:checkImage];
+    check.translatesAutoresizingMaskIntoConstraints = NO;
+    check.contentTintColor = [BSPDemoTheme feedbackAccent];
+    [circle addSubview:check];
+    [NSLayoutConstraint activateConstraints:@[
+        [circle.widthAnchor constraintEqualToConstant:80],
+        [circle.heightAnchor constraintEqualToConstant:80],
+        [check.centerXAnchor constraintEqualToAnchor:circle.centerXAnchor],
+        [check.centerYAnchor constraintEqualToAnchor:circle.centerYAnchor],
+    ]];
+
+    NSTextField *titleLabel = [NSTextField labelWithString:@"Feedback sent. Thanks!"];
+    titleLabel.font = [NSFont systemFontOfSize:22 weight:NSFontWeightBold];
+    titleLabel.textColor = [BSPDemoTheme textPrimary];
+    titleLabel.alignment = NSTextAlignmentCenter;
+
+    NSTextField *messageLabel =
+        [NSTextField wrappingLabelWithString:@"Your note made it to the BugSplat team. We reply within a day."];
+    messageLabel.font = [NSFont systemFontOfSize:13];
+    messageLabel.textColor = [BSPDemoTheme textSecondary];
+    messageLabel.alignment = NSTextAlignmentCenter;
+    messageLabel.selectable = NO;
+
+    NSView *reportRow = [self makeReportIdRow:reportId];
+
+    NSStackView *topStack = [NSStackView stackViewWithViews:@[ circle, titleLabel, messageLabel, reportRow ]];
+    topStack.translatesAutoresizingMaskIntoConstraints = NO;
+    topStack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    topStack.alignment = NSLayoutAttributeCenterX;
+    topStack.spacing = 14;
+    [topStack setCustomSpacing:18 afterView:messageLabel];
+
+    NSView *footer = [self makeThanksFooterWithResult:result];
+
+    [self.thanksContainer addSubview:topStack];
+    [self.thanksContainer addSubview:footer];
+    [NSLayoutConstraint activateConstraints:@[
+        [topStack.centerYAnchor constraintEqualToAnchor:self.thanksContainer.centerYAnchor constant:-36],
+        [topStack.leadingAnchor constraintEqualToAnchor:self.thanksContainer.leadingAnchor constant:32],
+        [topStack.trailingAnchor constraintEqualToAnchor:self.thanksContainer.trailingAnchor constant:-32],
+        [reportRow.leadingAnchor constraintEqualToAnchor:topStack.leadingAnchor],
+        [reportRow.trailingAnchor constraintEqualToAnchor:topStack.trailingAnchor],
+        [messageLabel.leadingAnchor constraintEqualToAnchor:topStack.leadingAnchor],
+        [messageLabel.trailingAnchor constraintEqualToAnchor:topStack.trailingAnchor],
+        [footer.leadingAnchor constraintEqualToAnchor:self.thanksContainer.leadingAnchor],
+        [footer.trailingAnchor constraintEqualToAnchor:self.thanksContainer.trailingAnchor],
+        [footer.bottomAnchor constraintEqualToAnchor:self.thanksContainer.bottomAnchor],
+    ]];
+
+    // Swap the sheet content: shrink to the thank-you size and cross-fade.
+    self.thanksContainer.alphaValue = 0;
+    self.preferredContentSize = NSMakeSize(kBSPFeedbackWidth, 470);
+    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
+        context.duration = 0.28;
+        self.formContainer.animator.alphaValue = 0;
+        self.thanksContainer.animator.alphaValue = 1;
+    } completionHandler:^{
+        self.formContainer.hidden = YES;
+    }];
+}
+
+- (NSView *)makeReportIdRow:(nullable NSString *)reportId {
+    NSTextField *label = [NSTextField labelWithAttributedString:
+        [[NSAttributedString alloc] initWithString:@"REPORT ID"
+            attributes:@{ NSFontAttributeName: [NSFont systemFontOfSize:10 weight:NSFontWeightSemibold],
+                          NSForegroundColorAttributeName: [BSPDemoTheme textTertiary],
+                          NSKernAttributeName: @1.1 }]];
+
+    NSTextField *idLabel = [NSTextField labelWithString:reportId ?: @"Unavailable"];
+    idLabel.font = [NSFont monospacedSystemFontOfSize:14 weight:NSFontWeightMedium];
+    idLabel.textColor = [BSPDemoTheme textPrimary];
+
+    NSView *spacer = [NSView new];
+    NSMutableArray *rowViews = [@[ label, idLabel, spacer ] mutableCopy];
+    if (reportId) {
+        NSButton *copy = [NSButton buttonWithTitle:@"Copy" target:self action:@selector(copyReportId:)];
+        copy.bezelStyle = NSBezelStyleRounded;
+        copy.font = [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold];
+        copy.identifier = reportId;
+        [rowViews addObject:copy];
+    }
+
+    NSStackView *row = [NSStackView stackViewWithViews:rowViews];
+    row.translatesAutoresizingMaskIntoConstraints = NO;
+    row.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+    row.alignment = NSLayoutAttributeCenterY;
+    row.spacing = 10;
+
+    NSView *card = [NSView new];
+    card.translatesAutoresizingMaskIntoConstraints = NO;
+    card.wantsLayer = YES;
+    card.layer.backgroundColor = [BSPDemoTheme badgeBg].CGColor;
+    card.layer.cornerRadius = 10;
+    [card addSubview:row];
+    [NSLayoutConstraint activateConstraints:@[
+        [row.topAnchor constraintEqualToAnchor:card.topAnchor constant:12],
+        [row.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-12],
+        [row.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:16],
+        [row.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-16],
+    ]];
+    return card;
+}
+
+- (void)copyReportId:(NSButton *)sender {
+    NSString *reportId = sender.identifier;
+    if (reportId.length == 0) return;
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    [pasteboard setString:reportId forType:NSPasteboardTypeString];
+}
+
+- (NSView *)makeThanksFooterWithResult:(BugSplatFeedbackResult *)result {
+    NSButton *dashboard = [NSButton buttonWithTitle:@"View on dashboard  ↗"
+                                             target:self
+                                             action:@selector(openReport:)];
+    dashboard.translatesAutoresizingMaskIntoConstraints = NO;
+    dashboard.bezelStyle = NSBezelStyleRounded;
+    dashboard.controlSize = NSControlSizeLarge;
+    dashboard.keyEquivalent = @"\r";
+    dashboard.bezelColor = [BSPDemoTheme feedbackAccent];
+    // Stash the result on the controller so the action can build the URL.
+    self.thanksResult = result;
+    [dashboard.heightAnchor constraintEqualToConstant:36].active = YES;
+
+    NSButton *close = [NSButton buttonWithTitle:@"Close" target:self action:@selector(closeTapped)];
+    close.bordered = NO;
+    close.contentTintColor = [BSPDemoTheme textSecondary];
+    close.font = [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold];
+
+    NSView *poweredBy = [self makePoweredByView];
+
+    NSStackView *stack = [NSStackView stackViewWithViews:@[ dashboard, close, poweredBy ]];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
+    stack.alignment = NSLayoutAttributeCenterX;
+    stack.spacing = 12;
+    stack.edgeInsets = NSEdgeInsetsMake(14, 20, 20, 20);
+
+    return [self footerContainerWithContent:stack stretchView:dashboard];
+}
+
+/// "Powered by BugSplat" where the word BugSplat links to bugsplat.com.
+- (NSView *)makePoweredByView {
+    NSTextField *prefix = [NSTextField labelWithString:@"Powered by"];
+    prefix.font = [NSFont systemFontOfSize:12];
+    prefix.textColor = [BSPDemoTheme textTertiary];
+
+    NSButton *link = [NSButton buttonWithTitle:@"BugSplat" target:self action:@selector(openBugSplatSite)];
+    link.bordered = NO;
+    link.contentTintColor = [BSPDemoTheme link];
+    link.font = [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold];
+
+    NSStackView *row = [NSStackView stackViewWithViews:@[ prefix, link ]];
+    row.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+    row.alignment = NSLayoutAttributeCenterY;
+    row.spacing = 2;
+    return row;
+}
+
+- (void)openBugSplatSite {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://bugsplat.com"]];
+}
+
+/// Links directly to the report by id. Feedback reports group by their (unique)
+/// title, so the SDK's infoUrl resolves to a generic page — prefer the id-scoped
+/// crash URL, falling back to the database dashboard.
+- (void)openReport:(id)sender {
+    NSURLComponents *components;
+    if (self.thanksResult.crashId) {
+        components = [NSURLComponents componentsWithString:@"https://app.bugsplat.com/v2/crash"];
+        components.queryItems = @[
+            [NSURLQueryItem queryItemWithName:@"database" value:[self database]],
+            [NSURLQueryItem queryItemWithName:@"id" value:self.thanksResult.crashId.stringValue],
+        ];
+    } else {
+        components = [NSURLComponents componentsWithString:@"https://app.bugsplat.com/v2/dashboard"];
+        components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"database" value:[self database]] ];
+    }
+    if (components.URL) {
+        [[NSWorkspace sharedWorkspace] openURL:components.URL];
+    }
+}
+
+@end

--- a/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
+++ b/Example_Apps/BugSplatTest-macOS-UIKit-ObjC/BugSplatTest-macOS-UIKit-ObjC/ViewController.m
@@ -9,6 +9,7 @@
 #import "BSPDemoTheme.h"
 #import "BSPDemoViews.h"
 #import "BSPActivityLog.h"
+#import "BSPFeedbackViewController.h"
 #import <BugSplat/BugSplat.h>
 
 // Splat gesture: 6 distinct keys within a tight 0.5s window. 6 is below the
@@ -23,7 +24,6 @@ static NSInteger const kBSPSplatGestureKeyCount = 6;
 @property (nonatomic, strong) NSStackView *recentActivityList;
 @property (nonatomic, strong) NSTextField *recentEmptyLabel;
 @property (nonatomic, strong) NSTextField *footerLabel;
-@property (nonatomic, strong) NSAttributedString *defaultFooterText;
 @property (nonatomic, strong) id keyDownMonitor;
 @property (nonatomic, strong) NSMutableSet<NSNumber *> *pressedKeyCodes;
 @property (nonatomic, assign) NSTimeInterval splatWindowStart;
@@ -352,23 +352,7 @@ static NSInteger const kBSPSplatGestureKeyCount = 6;
 
     label.attributedStringValue = str;
     self.footerLabel = label;
-    self.defaultFooterText = [str copy];
     return label;
-}
-
-/// Replace the footer with a plain status message, or restore the splat-prompt
-/// when `status` is nil. Matches the iOS samples' feedbackStatus behavior so
-/// the user can see success/failure of a feedback submission.
-- (void)showFeedbackStatus:(nullable NSString *)status {
-    if (status.length == 0) {
-        self.footerLabel.attributedStringValue = self.defaultFooterText;
-        return;
-    }
-    NSDictionary *attrs = @{
-        NSFontAttributeName: [NSFont systemFontOfSize:13],
-        NSForegroundColorAttributeName: BSPDemoTheme.textSecondary,
-    };
-    self.footerLabel.attributedStringValue = [[NSAttributedString alloc] initWithString:status attributes:attrs];
 }
 
 #pragma mark - Recent activity rendering
@@ -436,60 +420,28 @@ static NSInteger const kBSPSplatGestureKeyCount = 6;
 }
 
 - (void)triggerFeedback:(id)sender {
+    // Don't stack a second feedback sheet if one is already showing.
+    for (NSViewController *vc in self.presentedViewControllers) {
+        if ([vc isKindOfClass:[BSPFeedbackViewController class]]) return;
+    }
+
+    // Block the splat gesture / Cmd+digit while the sheet is up so typing in
+    // the feedback form doesn't re-trigger feedback.
     self.feedbackInProgress = YES;
     [self.pressedKeyCodes removeAllObjects];
     self.splatWindowStart = 0;
 
-    NSAlert *alert = [[NSAlert alloc] init];
-    alert.messageText = @"Send Feedback";
-    [alert addButtonWithTitle:@"Send"];
-    [alert addButtonWithTitle:@"Cancel"];
-
-    NSTextField *titleField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 320, 22)];
-    titleField.placeholderString = @"Title";
-    NSTextField *descField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 320, 22)];
-    descField.placeholderString = @"Description (optional)";
-
-    NSStackView *stack = [[NSStackView alloc] initWithFrame:NSMakeRect(0, 0, 320, 52)];
-    stack.orientation = NSUserInterfaceLayoutOrientationVertical;
-    stack.spacing = 8;
-    [stack addArrangedSubview:titleField];
-    [stack addArrangedSubview:descField];
-    alert.accessoryView = stack;
-    [alert.window setInitialFirstResponder:titleField];
-
-    NSModalResponse response = [alert runModal];
-    NSString *title = [titleField.stringValue
-                       stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    NSString *desc = descField.stringValue.length > 0 ? descField.stringValue : nil;
-
-    self.feedbackInProgress = NO;
-    [self.pressedKeyCodes removeAllObjects];
-    self.splatWindowStart = 0;
-
-    // Treat Cancel and empty-title-Send the same way: no submission, no record.
-    if (response != NSAlertFirstButtonReturn || title.length == 0) return;
-
-    [self showFeedbackStatus:@"Sending feedback…"];
-    [[BugSplat shared] postFeedback:title
-                        description:desc
-                           userName:nil
-                          userEmail:nil
-                             appKey:nil
-                        attachments:nil
-                         completion:^(NSError * _Nullable error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (error) {
-                NSString *msg = [NSString stringWithFormat:@"Feedback failed: %@", error.localizedDescription];
-                [self showFeedbackStatus:msg];
-                return;
-            }
-            NSString *detail = [NSString stringWithFormat:@"“%@”", title];
-            [BSPActivityLog record:BSPActivityTypeFeedback detail:detail];
-            [self renderRecentActivity];
-            [self showFeedbackStatus:@"Feedback sent — thank you!"];
-        });
-    }];
+    BSPFeedbackViewController *feedback = [[BSPFeedbackViewController alloc] init];
+    __weak typeof(self) weakSelf = self;
+    feedback.onDismiss = ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        strongSelf.feedbackInProgress = NO;
+        [strongSelf.pressedKeyCodes removeAllObjects];
+        strongSelf.splatWindowStart = 0;
+        [strongSelf renderRecentActivity];
+    };
+    [self presentViewControllerAsSheet:feedback];
 }
 
 - (void)triggerHang:(id)sender {

--- a/Tests/BugSplatTests/BugSplatUploadServiceTests.m
+++ b/Tests/BugSplatTests/BugSplatUploadServiceTests.m
@@ -917,6 +917,47 @@
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
+- (void)testUploadFeedback_IgnoresNonNumericStringCrashId
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    // A malformed (non-numeric) crashId must not be surfaced as a bogus @0.
+    NSDictionary *commitResponse = @{@"status": @"success",
+                                     @"crashId": @"not-a-number",
+                                     @"infoUrl": @"https://app.bugsplat.com/v2/crash"};
+    NSData *commitData = [NSJSONSerialization dataWithJSONObject:commitResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:commitData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(result);
+        XCTAssertNil(result.crashId, @"A non-numeric string crashId should be dropped, not parsed to @0");
+        XCTAssertEqualObjects(result.infoUrl, @"https://app.bugsplat.com/v2/crash");
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
 - (void)testUploadFeedback_SendsAttributesInCommitRequest
 {
     NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};

--- a/Tests/BugSplatTests/BugSplatUploadServiceTests.m
+++ b/Tests/BugSplatTests/BugSplatUploadServiceTests.m
@@ -77,7 +77,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertTrue(success);
         XCTAssertNil(error);
         XCTAssertEqualObjects(infoUrl, @"https://bugsplat.com/crash/123");
@@ -112,7 +112,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         [expectation fulfill];
     }];
     
@@ -150,7 +150,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         [expectation fulfill];
     }];
     
@@ -184,7 +184,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         [expectation fulfill];
     }];
     
@@ -206,7 +206,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -223,7 +223,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -246,7 +246,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, NSURLErrorNotConnectedToInternet);
@@ -269,7 +269,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         // Rate limit error code is 4
@@ -292,7 +292,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -315,7 +315,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -339,7 +339,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertFalse(success);
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -378,7 +378,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:metadata
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         [expectation fulfill];
     }];
     
@@ -429,7 +429,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:nil
                                  metadata:metadata
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         [expectation fulfill];
     }];
     
@@ -478,7 +478,7 @@
                             crashFilename:@"crash.crashlog"
                               attachments:@[attachment]
                                  metadata:nil
-                               completion:^(BOOL success, NSError *error, NSString *infoUrl) {
+                               completion:^(BOOL success, NSError *error, NSString *infoUrl, NSNumber *crashId) {
         XCTAssertTrue(success);
         [expectation fulfill];
     }];
@@ -568,8 +568,9 @@
                            description:@"A test description"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNil(error);
+        XCTAssertNotNil(result);
         [expectation fulfill];
     }];
 
@@ -602,7 +603,7 @@
                            description:@"Desc"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         [expectation fulfill];
     }];
 
@@ -641,7 +642,7 @@
                            description:@"Desc"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         [expectation fulfill];
     }];
 
@@ -667,7 +668,7 @@
                            description:@"Desc"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertTrue([error.localizedDescription containsString:@"title"]);
         [expectation fulfill];
@@ -688,7 +689,7 @@
                            description:@"Desc"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         [expectation fulfill];
     }];
@@ -750,7 +751,7 @@
                            description:@"Desc"
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         [expectation fulfill];
     }];
@@ -788,7 +789,7 @@
                            description:@"Desc"
                            attachments:@[attachment]
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNil(error);
         [expectation fulfill];
     }];
@@ -828,13 +829,132 @@
                            description:nil
                            attachments:nil
                               metadata:metadata
-                            completion:^(NSError * _Nullable error) {
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
         XCTAssertNil(error);
         [expectation fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
     XCTAssertEqual(self.mockSession.requestCount, 3);
+}
+
+- (void)testUploadFeedback_SurfacesCrashIdAndInfoUrl
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    // commitS3CrashUpload returns crashId (integer) and infoUrl
+    NSDictionary *commitResponse = @{@"status": @"success",
+                                     @"crashId": @987654,
+                                     @"infoUrl": @"https://app.bugsplat.com/v2/crash?id=987654"};
+    NSData *commitData = [NSJSONSerialization dataWithJSONObject:commitResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:commitData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(result);
+        XCTAssertEqualObjects(result.crashId, @987654);
+        XCTAssertEqualObjects(result.infoUrl, @"https://app.bugsplat.com/v2/crash?id=987654");
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testUploadFeedback_SurfacesStringEncodedCrashId
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    // Tolerate a crashId delivered as a JSON string
+    NSDictionary *commitResponse = @{@"status": @"success", @"crashId": @"42"};
+    NSData *commitData = [NSJSONSerialization dataWithJSONObject:commitResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:commitData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(result);
+        XCTAssertEqualObjects(result.crashId, @42);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testUploadFeedback_SendsAttributesInCommitRequest
+{
+    NSDictionary *presignedResponse = @{@"url": @"https://s3.example.com/test"};
+    NSData *presignedData = [NSJSONSerialization dataWithJSONObject:presignedResponse options:0 error:nil];
+    [self.mockSession queueResponseWithData:presignedData
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:nil
+                                   response:[MockURLSession responseWithStatusCode:200]
+                                      error:nil];
+    [self.mockSession queueResponseWithData:[@"{}" dataUsingEncoding:NSUTF8StringEncoding]
+                                   response:[MockURLSession jsonResponseWithStatusCode:200]
+                                      error:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Feedback upload completes"];
+
+    BugSplatCrashMetadata *metadata = [[BugSplatCrashMetadata alloc] init];
+    metadata.database = @"testdb";
+    metadata.applicationName = @"TestApp";
+    metadata.applicationVersion = @"1.0.0";
+    metadata.attributes = @{@"category": @"Bug"};
+
+    [self.uploadService uploadFeedback:@"Title"
+                           description:@"Desc"
+                           attachments:nil
+                              metadata:metadata
+                            completion:^(BugSplatFeedbackResult * _Nullable result, NSError * _Nullable error) {
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // The commit request (3rd request) should carry the attributes as a JSON form field
+    MockURLSessionRequest *commitRequest = self.mockSession.recordedRequests[2];
+    NSString *bodyString = [[NSString alloc] initWithData:commitRequest.request.HTTPBody encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([bodyString containsString:@"attributes"]);
+    XCTAssertTrue([bodyString containsString:@"category"]);
+    XCTAssertTrue([bodyString containsString:@"Bug"]);
 }
 
 @end


### PR DESCRIPTION
## Summary

Ports the bugsplat-android User Feedback redesign (PR #22) to this repo: a richer feedback form presented as a bottom sheet / modal, and a thank-you confirmation screen shown after submission. Also extends the SDK so the thank-you screen can display the submitted report id.

## SDK change (backward compatible)

The feedback-submit path previously reported only success/error. It now surfaces the report id.

- **New public type `BugSplatFeedbackResult`** — immutable, exposes `crashId` (the integer report id) and `infoUrl`, parsed from the `commitS3CrashUpload` JSON response.
- **New `postFeedback` overload** — `postFeedback:description:userName:userEmail:appKey:attributes:attachments:completion:` accepts a custom `attributes` dictionary and a completion returning a `BugSplatFeedbackResult`. The existing `NSError`-only `postFeedback` is kept verbatim and now delegates to the new method, so all current callers are unaffected.
- Internally, the (internal, non-umbrella) `BugSplatUploadCompletion` typedef is widened to carry the parsed `crashId`; the commit step now also reads `crashId` (tolerating a string-encoded value). `BugSplatFeedbackResult.h/.m` is registered as a public header in the iOS/macOS/tvOS framework targets.
- **Tests**: existing crash/feedback upload tests updated to the new completion shapes; added coverage for `crashId` parsing (numeric + string-encoded) and for `attributes` reaching the commit request. `BugSplatIOSTests` and `BugSplatMacTests` pass.

## New feedback UI

Applied to **BugSplatTest-SwiftUI, -UIKit-Swift, -UIKit-ObjC, and -macOS-UIKit-ObjC**, each built natively (SwiftUI / programmatic UIKit / programmatic AppKit) against its existing design system.

> `BugSplatTest-SwiftUI-SPM` is intentionally **not** changed — it consumes BugSplat as a published binary xcframework and cannot see the unreleased SDK API. It still uses the previous alert. It should be updated after the next SDK release.

**Form** — "Send feedback" sheet with a close control; Bug/Feature/Other segmented selector (sent as `{"category": …}`); Title (required, red asterisk), Description (multi-line), Name, Email (optional); an Attachment row with a real file picker (`fileImporter` / `UIDocumentPickerViewController` / `NSOpenPanel`) showing name + size + type chip + Replace; an "Include logs" toggle (default on) that attaches the app's existing `sample_log.txt`; a footer hint and a primary Send button with a loading state. Title-required validation; submit failure keeps all input.

**Thank-you** — swapped into the same sheet on success: green check, "Feedback sent. Thanks!", a REPORT ID row with the real numeric `crashId` and copy-to-clipboard, a "View on dashboard" button linking directly to the report (`app.bugsplat.com/v2/crash?database=…&id=…`, falling back to the database dashboard if the id is unavailable), a Close button, and a "Powered by BugSplat" footer linking to bugsplat.com.

## Verification

- All three SDK framework schemes (iOS/macOS/tvOS) build; `BugSplatIOSTests` + `BugSplatMacTests` pass.
- All four example app schemes build (iOS Simulator / My Mac).
- `plutil -lint` clean on every edited `project.pbxproj`.

## Not verified in this environment

- **On-device / live submission behavior** — submitting against a live BugSplat database, the real `crashId` returned by the server, and the resulting dashboard deep link were not exercised; only mocked-network unit tests cover the SDK path.
- **Interactive UI** — the sheet presentation, file pickers, shake / 6-key-splat triggers, and the thank-you swap animation were not run on a device; verified only via successful builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)