### PR TITLE
fix: red close button cancels crash dialog and unblocks modal (#59, #60)

### DIFF
--- a/BugSplatCrashReportWindow.m
+++ b/BugSplatCrashReportWindow.m
@@ -492,6 +492,8 @@ static const CGFloat kDetailsHeight = 200.0;
 - (void)showWithCompletion:(BugSplatCrashReportCompletion)completion
 {
     self.completion = completion;
+    self.isModal = NO;
+    self.pendingAction = BugSplatUserActionCancel;
     [self updateUI];
     
     // Let Auto Layout calculate the size
@@ -517,6 +519,7 @@ static const CGFloat kDetailsHeight = 200.0;
 {
     self.completion = completion;
     self.isModal = YES;
+    self.pendingAction = BugSplatUserActionCancel;
     [self updateUI];
     
     // Let Auto Layout calculate the size

--- a/BugSplatCrashReportWindow.m
+++ b/BugSplatCrashReportWindow.m
@@ -44,7 +44,7 @@ static const CGFloat kDetailsHeight = 200.0;
 
 @property (nonatomic, copy) BugSplatCrashReportCompletion completion;
 @property (nonatomic, strong) NSLayoutConstraint *detailsHeightConstraint;
-@property (nonatomic, assign) BOOL didFinish;
+@property (nonatomic, assign) BugSplatUserAction pendingAction;
 @property (nonatomic, assign) BOOL isModal;
 
 @end
@@ -62,8 +62,12 @@ static const CGFloat kDetailsHeight = 200.0;
     if (self) {
         _askUserDetails = YES;
 
-        // Become the window delegate so we can treat the title bar's red close
-        // button the same as Cancel (see windowWillClose:).
+        // Default to Cancel so dismissing via the title bar's red close button
+        // discards the report (see windowWillClose:).
+        _pendingAction = BugSplatUserActionCancel;
+
+        // Become the window delegate so every dismissal funnels through
+        // windowWillClose:, our single exit point.
         window.delegate = self;
 
         [self setupUI];
@@ -550,51 +554,14 @@ static const CGFloat kDetailsHeight = 200.0;
 
 - (void)sendClicked:(id)sender
 {
-    NSString *name = self.nameField.stringValue ?: @"";
-    NSString *email = self.emailField.stringValue ?: @"";
-    NSString *comments = self.commentsTextView.string ?: @"";
-
-    [self finishWithAction:BugSplatUserActionSend userName:name userEmail:email comments:comments];
+    self.pendingAction = BugSplatUserActionSend;
+    [self.window close];
 }
 
 - (void)cancelClicked:(id)sender
 {
-    [self finishWithAction:BugSplatUserActionCancel userName:nil userEmail:nil comments:nil];
-}
-
-// Single exit point for the dialog. Routes Send, Cancel, and the title bar's
-// red close button through the same teardown so the modal session is always
-// ended and the completion handler always fires exactly once.
-- (void)finishWithAction:(BugSplatUserAction)action
-                userName:(nullable NSString *)userName
-               userEmail:(nullable NSString *)userEmail
-                comments:(nullable NSString *)comments
-{
-    if (self.didFinish) {
-        return;
-    }
-    self.didFinish = YES;
-
-    // Hold a strong reference for the duration of this method: invoking the
-    // completion handler typically releases the only external reference to this
-    // controller (BugSplat sets crashReportWindow = nil), which would otherwise
-    // deallocate self mid-method.
-    __strong typeof(self) strongSelf = self;
-
-    BugSplatCrashReportCompletion completion = strongSelf.completion;
-    strongSelf.completion = nil;
-
-    // Closing the window triggers windowWillClose:, but didFinish guards against
-    // re-entrancy so this is safe to call here.
-    [strongSelf.window close];
-
-    if (strongSelf.isModal) {
-        [NSApp stopModal];
-    }
-
-    if (completion) {
-        completion(action, userName, userEmail, comments);
-    }
+    self.pendingAction = BugSplatUserActionCancel;
+    [self.window close];
 }
 
 - (void)placeholderClicked:(NSGestureRecognizer *)gesture
@@ -635,15 +602,30 @@ static const CGFloat kDetailsHeight = 200.0;
 
 - (void)windowWillClose:(NSNotification *)notification
 {
-    // Reached when the user clicks the title bar's red close button (Send/Cancel
-    // set didFinish first via finishWithAction:). Treat it as Cancel so the crash
-    // report is discarded, the modal session ends, and the delegate is notified —
-    // instead of leaving the report pending and, in modal mode, hanging the app.
-    if (self.didFinish) {
-        return;
+    BugSplatCrashReportCompletion completion = self.completion;
+    self.completion = nil;
+    if (!completion) {
+        return; // Already handled (guards against a second close notification).
     }
 
-    [self finishWithAction:BugSplatUserActionCancel userName:nil userEmail:nil comments:nil];
+    NSString *name = nil, *email = nil, *comments = nil;
+    if (self.pendingAction == BugSplatUserActionSend) {
+        name = self.nameField.stringValue ?: @"";
+        email = self.emailField.stringValue ?: @"";
+        comments = self.commentsTextView.string ?: @"";
+    }
+
+    if (self.isModal) {
+        [NSApp stopModal];
+    }
+
+    // Defer the completion to the next runloop tick. It releases this controller
+    // (BugSplat sets crashReportWindow = nil), so running it now would deallocate
+    // the window while it is still mid-close.
+    BugSplatUserAction action = self.pendingAction;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(action, name, email, comments);
+    });
 }
 
 #pragma mark - NSTextStorageDelegate

--- a/BugSplatCrashReportWindow.m
+++ b/BugSplatCrashReportWindow.m
@@ -18,7 +18,7 @@ static const CGFloat kButtonWidth = 100.0;
 static const CGFloat kButtonHeight = 32.0;
 static const CGFloat kDetailsHeight = 200.0;
 
-@interface BugSplatCrashReportWindow () <NSTextStorageDelegate>
+@interface BugSplatCrashReportWindow () <NSTextStorageDelegate, NSWindowDelegate>
 
 @property (nonatomic, strong) NSStackView *mainStackView;
 @property (nonatomic, strong) NSImageView *bannerImageView;
@@ -44,6 +44,8 @@ static const CGFloat kDetailsHeight = 200.0;
 
 @property (nonatomic, copy) BugSplatCrashReportCompletion completion;
 @property (nonatomic, strong) NSLayoutConstraint *detailsHeightConstraint;
+@property (nonatomic, assign) BOOL didFinish;
+@property (nonatomic, assign) BOOL isModal;
 
 @end
 
@@ -59,7 +61,11 @@ static const CGFloat kDetailsHeight = 200.0;
     self = [super initWithWindow:window];
     if (self) {
         _askUserDetails = YES;
-        
+
+        // Become the window delegate so we can treat the title bar's red close
+        // button the same as Cancel (see windowWillClose:).
+        window.delegate = self;
+
         [self setupUI];
     }
     return self;
@@ -506,6 +512,7 @@ static const CGFloat kDetailsHeight = 200.0;
 - (void)showModalWithCompletion:(BugSplatCrashReportCompletion)completion
 {
     self.completion = completion;
+    self.isModal = YES;
     [self updateUI];
     
     // Let Auto Layout calculate the size
@@ -546,22 +553,47 @@ static const CGFloat kDetailsHeight = 200.0;
     NSString *name = self.nameField.stringValue ?: @"";
     NSString *email = self.emailField.stringValue ?: @"";
     NSString *comments = self.commentsTextView.string ?: @"";
-    
-    [self.window close];
-    [NSApp stopModal];
-    
-    if (self.completion) {
-        self.completion(BugSplatUserActionSend, name, email, comments);
-    }
+
+    [self finishWithAction:BugSplatUserActionSend userName:name userEmail:email comments:comments];
 }
 
 - (void)cancelClicked:(id)sender
 {
-    [self.window close];
-    [NSApp stopModal];
-    
-    if (self.completion) {
-        self.completion(BugSplatUserActionCancel, nil, nil, nil);
+    [self finishWithAction:BugSplatUserActionCancel userName:nil userEmail:nil comments:nil];
+}
+
+// Single exit point for the dialog. Routes Send, Cancel, and the title bar's
+// red close button through the same teardown so the modal session is always
+// ended and the completion handler always fires exactly once.
+- (void)finishWithAction:(BugSplatUserAction)action
+                userName:(nullable NSString *)userName
+               userEmail:(nullable NSString *)userEmail
+                comments:(nullable NSString *)comments
+{
+    if (self.didFinish) {
+        return;
+    }
+    self.didFinish = YES;
+
+    // Hold a strong reference for the duration of this method: invoking the
+    // completion handler typically releases the only external reference to this
+    // controller (BugSplat sets crashReportWindow = nil), which would otherwise
+    // deallocate self mid-method.
+    __strong typeof(self) strongSelf = self;
+
+    BugSplatCrashReportCompletion completion = strongSelf.completion;
+    strongSelf.completion = nil;
+
+    // Closing the window triggers windowWillClose:, but didFinish guards against
+    // re-entrancy so this is safe to call here.
+    [strongSelf.window close];
+
+    if (strongSelf.isModal) {
+        [NSApp stopModal];
+    }
+
+    if (completion) {
+        completion(action, userName, userEmail, comments);
     }
 }
 
@@ -597,6 +629,21 @@ static const CGFloat kDetailsHeight = 200.0;
         [self.window.animator setFrame:frame display:YES];
         
     } completionHandler:nil];
+}
+
+#pragma mark - NSWindowDelegate
+
+- (void)windowWillClose:(NSNotification *)notification
+{
+    // Reached when the user clicks the title bar's red close button (Send/Cancel
+    // set didFinish first via finishWithAction:). Treat it as Cancel so the crash
+    // report is discarded, the modal session ends, and the delegate is notified —
+    // instead of leaving the report pending and, in modal mode, hanging the app.
+    if (self.didFinish) {
+        return;
+    }
+
+    [self finishWithAction:BugSplatUserActionCancel userName:nil userEmail:nil comments:nil];
 }
 
 #pragma mark - NSTextStorageDelegate


### PR DESCRIPTION
## Summary

The macOS crash report window had no `NSWindowDelegate`, so the title bar's red close button closed the window without firing the completion handler or ending the modal session. Both reported issues share this root cause.

Fixes #59
Fixes #60

## Changes

- Make `BugSplatCrashReportWindow` its own window delegate.
- Every dismissal — **Send**, **Cancel**, and the **red close button** — funnels through the window's `windowWillClose:` delegate method, the single exit point.
- `pendingAction` (default `Cancel`) records the user's choice; the red close button falls through to Cancel with no special casing, so it discards the report and fires `bugSplatWillCancelSendingCrashReport`.
- The completion handler is deferred to the next runloop tick: invoking it releases this controller (`BugSplat` sets `crashReportWindow = nil`), so running it synchronously could deallocate the window mid-close. A double-close no-ops because `completion` is nil'd on the first pass.
- `[NSApp stopModal]` is only called when the dialog was actually presented modally (`presentModally` defaults to `NO`).

## Behavior fixed

| Issue | Before | After |
|-------|--------|-------|
| #59 | Red button left report pending; dialog reappeared next launch; delegate never notified | Red button discards report, cleans up, fires `bugSplatWillCancelSendingCrashReport` |
| #60 | Red button in modal mode never called `stopModal` → app hung | Modal session ends; main thread unblocked |

## Testing

- Builds clean: `xcodebuild build -scheme BugSplatMac -destination 'platform=macOS'` (only a pre-existing unrelated warning).

## Follow-up

This is a minimal, surgical fix. #62 tracks the deeper design concerns uncovered during review (e.g. `presentModally` blocking the main thread via `runModalForWindow:`, manual animation pre-warming, fully programmatic UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)